### PR TITLE
add ingresses on topology

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,14 +183,6 @@ issues:
     - path: pkg/acp/admission/reviewer/reviewer.go
       linters:
         - goconst
-    - path: pkg/topology/state/fetcher.go
-      text: "Function 'watchAll' has too many statements"
-      linters:
-        - funlen
-    - path: pkg/topology/state/fetcher.go
-      text: "cyclomatic complexity 19 of func `watchAll` is high"
-      linters:
-        - gocyclo
     - path: pkg/metrics/protocol/protocol.go
       text: '[[:alpha:]]+V\dSchema is a global variable'
     # False positive.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,11 +183,22 @@ issues:
     - path: pkg/acp/admission/reviewer/reviewer.go
       linters:
         - goconst
+    - path: pkg/topology/state/fetcher.go
+      text: "Function 'watchAll' has too many statements"
+      linters:
+        - funlen
+    - path: pkg/topology/state/fetcher.go
+      text: "cyclomatic complexity 19 of func `watchAll` is high"
+      linters:
+        - gocyclo
     - path: pkg/metrics/protocol/protocol.go
       text: '[[:alpha:]]+V\dSchema is a global variable'
     # False positive.
     - path: pkg/metrics/store_test.go
       text: 'Multiplication of durations: `-1 \* time\.Duration\(n\) \* gran`'
+    # Keep for historical reason.
+    - path: pkg/topology/state/cluster.go
+      text: "json\\(camel\\): got '(metricsURLs)' want '(metricsUrLs)'"
     # Reducing cyclomatic complexity would reduce readability.
     - path: pkg/acp/admission/reviewer/traefik_ingress_route.go
       linters:

--- a/cmd/agent/controller.go
+++ b/cmd/agent/controller.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/ettle/strcase"
+	traefikclientset "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/clientset/versioned"
 	"github.com/traefik/hub-agent-kubernetes/pkg/heartbeat"
 	"github.com/traefik/hub-agent-kubernetes/pkg/kube"
 	"github.com/traefik/hub-agent-kubernetes/pkg/logger"
@@ -110,6 +111,11 @@ func (c controllerCmd) run(cliCtx *cli.Context) error {
 		return fmt.Errorf("create Kubernetes client set: %w", err)
 	}
 
+	traefikClientSet, err := traefikclientset.NewForConfig(kubeCfg)
+	if err != nil {
+		return fmt.Errorf("create Traefik client set: %w", err)
+	}
+
 	platformClient, err := platform.NewClient(platformURL, token)
 	if err != nil {
 		return fmt.Errorf("build platform client: %w", err)
@@ -124,7 +130,7 @@ func (c controllerCmd) run(cliCtx *cli.Context) error {
 		return fmt.Errorf("setup agent: %w", err)
 	}
 
-	topoFetcher, err := state.NewFetcher(cliCtx.Context)
+	topoFetcher, err := state.NewFetcher(cliCtx.Context, kubeClient, traefikClientSet)
 	if err != nil {
 		return err
 	}

--- a/pkg/topology/state/cluster.go
+++ b/pkg/topology/state/cluster.go
@@ -18,14 +18,24 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 package state
 
 import (
+	traefikv1alpha1 "github.com/traefik/hub-agent-kubernetes/pkg/crd/api/traefik/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 )
 
 // Cluster describes a Cluster.
 type Cluster struct {
-	Services  map[string]*Service `json:"services"`
-	Ingresses map[string]*Ingress `json:"-"`
+	Ingresses     map[string]*Ingress      `json:"ingresses"`
+	IngressRoutes map[string]*IngressRoute `json:"ingressRoutes"`
+	Services      map[string]*Service      `json:"services"`
+}
+
+// ResourceMeta represents the metadata which identify a Kubernetes resource.
+type ResourceMeta struct {
+	Kind      string `json:"kind"`
+	Group     string `json:"group"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 // Service describes a Service.
@@ -38,18 +48,9 @@ type Service struct {
 	ExternalPorts []int              `json:"externalPorts,omitempty"`
 }
 
-// ResourceMeta represents the metadata which identify a Kubernetes resource.
-type ResourceMeta struct {
-	Kind      string `json:"kind"`
-	Group     string `json:"group"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
-}
-
 // IngressMeta represents the common Ingress metadata properties.
 type IngressMeta struct {
-	ControllerType string            `json:"controllerType,omitempty"`
-	Annotations    map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // Ingress describes an Kubernetes Ingress.
@@ -62,4 +63,41 @@ type Ingress struct {
 	Rules            []netv1.IngressRule   `json:"rules,omitempty"`
 	DefaultBackend   *netv1.IngressBackend `json:"defaultBackend,omitempty"`
 	Services         []string              `json:"services,omitempty"`
+}
+
+// IngressRoute describes a Traefik IngressRoute.
+type IngressRoute struct {
+	ResourceMeta
+	IngressMeta
+
+	TLS      *IngressRouteTLS `json:"tls,omitempty"`
+	Routes   []Route          `json:"routes,omitempty"`
+	Services []string         `json:"services,omitempty"`
+}
+
+// IngressRouteTLS represents a simplified Traefik IngressRoute TLS configuration.
+type IngressRouteTLS struct {
+	Domains    []traefikv1alpha1.Domain `json:"domains,omitempty"`
+	SecretName string                   `json:"secretName,omitempty"`
+	Options    *TLSOptionRef            `json:"options,omitempty"`
+}
+
+// TLSOptionRef references TLSOptions.
+type TLSOptionRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// Route represents a Traefik IngressRoute route.
+type Route struct {
+	Match    string         `json:"match"`
+	Services []RouteService `json:"services,omitempty"`
+}
+
+// RouteService represents a Kubernetes service targeted by a Traefik IngressRoute route.
+type RouteService struct {
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	PortName   string `json:"portName,omitempty"`
+	PortNumber int32  `json:"portNumber,omitempty"`
 }

--- a/pkg/topology/state/fetcher.go
+++ b/pkg/topology/state/fetcher.go
@@ -24,8 +24,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/rs/zerolog/log"
+	traefikv1alpha1 "github.com/traefik/hub-agent-kubernetes/pkg/crd/api/traefik/v1alpha1"
+	traefikclientset "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/clientset/versioned"
+	traefikinformer "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/informers/externalversions"
 	"github.com/traefik/hub-agent-kubernetes/pkg/kube"
 	"github.com/traefik/hub-agent-kubernetes/pkg/kubevers"
+	kerror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -35,6 +41,7 @@ type Fetcher struct {
 	serverVersion string
 
 	k8s       informers.SharedInformerFactory
+	traefik   traefikinformer.SharedInformerFactory
 	clientSet clientset.Interface
 }
 
@@ -50,15 +57,20 @@ func NewFetcher(ctx context.Context) (*Fetcher, error) {
 		return nil, err
 	}
 
+	traefikClientSet, err := traefikclientset.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
 	serverVersion, err := clientSet.Discovery().ServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("get server version: %w", err)
 	}
 
-	return watchAll(ctx, clientSet, serverVersion.GitVersion)
+	return watchAll(ctx, clientSet, traefikClientSet, serverVersion.GitVersion)
 }
 
-func watchAll(ctx context.Context, clientSet clientset.Interface, serverVersion string) (*Fetcher, error) {
+func watchAll(ctx context.Context, clientSet clientset.Interface, traefikClientSet traefikclientset.Interface, serverVersion string) (*Fetcher, error) {
 	serverSemVer, err := version.NewVersion(serverVersion)
 	if err != nil {
 		return nil, fmt.Errorf("parse server version: %w", err)
@@ -86,7 +98,25 @@ func watchAll(ctx context.Context, clientSet clientset.Interface, serverVersion 
 		kubernetesFactory.Networking().V1beta1().Ingresses().Informer()
 	}
 
+	traefikFactory := traefikinformer.NewSharedInformerFactoryWithOptions(traefikClientSet, 5*time.Minute)
+
+	hasTraefikCRDs, err := hasTraefikCRDs(clientSet.Discovery())
+	if err != nil {
+		return nil, fmt.Errorf("check presence of Traefik IngressRoute, TraefikService and TLSOption CRD: %w", err)
+	}
+	if hasTraefikCRDs {
+		traefikFactory.Traefik().V1alpha1().IngressRoutes().Informer()
+		traefikFactory.Traefik().V1alpha1().TraefikServices().Informer()
+	} else {
+		msg := "The agent has been installed in a cluster where the Traefik Proxy CustomResourceDefinitions are not installed. " +
+			"If you want to install these CustomResourceDefinitions and take advantage of them in Traefik Hub, " +
+			"the agent needs to be restarted in order to load them. " +
+			"Run 'kubectl -n hub-agent delete pod -l app=hub-agent,component=controller'"
+		log.Info().Msg(msg)
+	}
+
 	kubernetesFactory.Start(ctx.Done())
+	traefikFactory.Start(ctx.Done())
 
 	for typ, ok := range kubernetesFactory.WaitForCacheSync(ctx.Done()) {
 		if !ok {
@@ -94,9 +124,16 @@ func watchAll(ctx context.Context, clientSet clientset.Interface, serverVersion 
 		}
 	}
 
+	for typ, ok := range traefikFactory.WaitForCacheSync(ctx.Done()) {
+		if !ok {
+			return nil, fmt.Errorf("timed out waiting for Traefik CRD caches to sync %s", typ)
+		}
+	}
+
 	return &Fetcher{
 		serverVersion: serverVersion,
 		k8s:           kubernetesFactory,
+		traefik:       traefikFactory,
 		clientSet:     clientSet,
 	}, nil
 }
@@ -117,7 +154,40 @@ func (f *Fetcher) FetchState() (*Cluster, error) {
 		return nil, err
 	}
 
+	cluster.IngressRoutes, err = f.getIngressRoutes()
+	if err != nil {
+		return nil, err
+	}
+
 	return &cluster, nil
+}
+
+func hasTraefikCRDs(clientSet discovery.DiscoveryInterface) (bool, error) {
+	crdList, err := clientSet.ServerResourcesForGroupVersion(traefikv1alpha1.SchemeGroupVersion.String())
+	if err != nil {
+		if kerror.IsNotFound(err) ||
+			// because the fake client doesn't return the right error type.
+			strings.HasSuffix(err.Error(), " not found") {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, kind := range []string{ResourceKindIngressRoute, ResourceKindTraefikService, ResourceKindTLSOption} {
+		var exists bool
+		for _, resource := range crdList.APIResources {
+			if resource.Kind == kind {
+				exists = true
+				break
+			}
+		}
+
+		if !exists {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func objectKey(name, ns string) string {

--- a/pkg/topology/state/fetcher_test.go
+++ b/pkg/topology/state/fetcher_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	traefikkubemock "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/clientset/versioned/fake"
 	netv1 "k8s.io/api/networking/v1"
 	netv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,8 +64,9 @@ func Test_watchAll_handlesUnsupportedVersions(t *testing.T) {
 			t.Parallel()
 
 			kubeClient := kubemock.NewSimpleClientset()
+			traefikClient := traefikkubemock.NewSimpleClientset()
 
-			_, err := watchAll(context.Background(), kubeClient, test.serverVersion)
+			_, err := watchAll(context.Background(), kubeClient, traefikClient, test.serverVersion)
 
 			test.wantErr(t, err)
 		})
@@ -88,6 +90,7 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 						Name:      "myIngress_netv1beta1",
 						Namespace: "myns",
 					},
+					IngressMeta: IngressMeta{},
 				},
 			},
 		},
@@ -102,6 +105,7 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 						Name:      "myIngress_netv1beta1",
 						Namespace: "myns",
 					},
+					IngressMeta: IngressMeta{},
 				},
 			},
 		},
@@ -116,6 +120,7 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 						Name:      "myIngress_netv1beta1",
 						Namespace: "myns",
 					},
+					IngressMeta: IngressMeta{},
 				},
 			},
 		},
@@ -130,6 +135,7 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 						Name:      "myIngress_netv1",
 						Namespace: "myns",
 					},
+					IngressMeta: IngressMeta{},
 				},
 			},
 		},
@@ -144,6 +150,7 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 						Name:      "myIngress_netv1",
 						Namespace: "myns",
 					},
+					IngressMeta: IngressMeta{},
 				},
 			},
 		},
@@ -170,8 +177,9 @@ func Test_watchAll_handlesAllIngressAPIVersions(t *testing.T) {
 			}
 
 			kubeClient := kubemock.NewSimpleClientset(k8sObjects...)
+			traefikClient := traefikkubemock.NewSimpleClientset()
 
-			f, err := watchAll(context.Background(), kubeClient, test.serverVersion)
+			f, err := watchAll(context.Background(), kubeClient, traefikClient, test.serverVersion)
 			require.NoError(t, err)
 
 			got, err := f.getIngresses()

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-one-internal-traefik-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-one-internal-traefik-service.yml
@@ -1,0 +1,15 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - kind: Rule
+      match: Host(`api.localhost`)
+      services:
+        - name: api@internal
+          kind: TraefikService

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-one-mirroring-traefik-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-one-mirroring-traefik-service.yml
@@ -1,0 +1,35 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: traefik-service
+          namespace: ns2
+          kind: TraefikService
+
+  tls:
+    secretName: secret
+    domains:
+      - main: foo.com
+        sans:
+          - bar.foo.com
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service
+  namespace: ns2
+
+spec:
+  mirroring:
+    name: service1
+    port: 80

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-one-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-one-service.yml
@@ -1,0 +1,22 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: service
+          port: 80
+
+  tls:
+    secretName: secret
+    domains:
+      - main: foo.com
+        sans:
+          - bar.foo.com

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-one-weighted-traefik-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-one-weighted-traefik-service.yml
@@ -1,0 +1,39 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: traefik-service
+          kind: TraefikService
+
+  tls:
+    secretName: secret
+    domains:
+      - main: foo.com
+        sans:
+          - bar.foo.com
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service
+  namespace: ns
+
+spec:
+  weighted:
+    services:
+      - name: service1
+        port: 80
+        weight: 1
+      - name: service2
+        port: 80
+        weight: 1

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-two-mirroring-traefik-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-two-mirroring-traefik-service.yml
@@ -1,0 +1,40 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: traefik-service1
+          namespace: ns2
+          kind: TraefikService
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service1
+  namespace: ns2
+
+spec:
+  mirroring:
+    name: traefik-service2
+    kind: TraefikService
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service2
+  namespace: ns2
+
+spec:
+  mirroring:
+    name: service
+    port: 80

--- a/pkg/topology/state/fixtures/ingress-route/ingress-route-two-weighted-traefik-service.yml
+++ b/pkg/topology/state/fixtures/ingress-route/ingress-route-two-weighted-traefik-service.yml
@@ -1,0 +1,54 @@
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: name
+  namespace: ns
+spec:
+  entryPoints:
+    - web
+
+  routes:
+    - match: Host(`foo.com`)
+      kind: Rule
+      services:
+        - name: traefik-service
+          kind: TraefikService
+
+  tls:
+    secretName: secret
+    domains:
+      - main: foo.com
+        sans:
+          - bar.foo.com
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service
+  namespace: ns
+
+spec:
+  weighted:
+    services:
+      - name: service1
+        port: 80
+      - name: traefik-service2
+        kind: TraefikService
+        namespace: ns2
+        port: 80
+
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: TraefikService
+metadata:
+  name: traefik-service2
+  namespace: ns2
+
+spec:
+  weighted:
+    services:
+      - name: service2
+        port: 80
+      - name: service3
+        port: 80

--- a/pkg/topology/state/ingress_route.go
+++ b/pkg/topology/state/ingress_route.go
@@ -1,0 +1,199 @@
+/*
+Copyright (C) 2022 Traefik Labs
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package state
+
+import (
+	"strings"
+
+	traefikv1alpha1 "github.com/traefik/hub-agent-kubernetes/pkg/crd/api/traefik/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// Supported Traefik CRD kinds.
+const (
+	ResourceKindIngressRoute   = "IngressRoute"
+	ResourceKindTraefikService = "TraefikService"
+	ResourceKindTLSOption      = "TLSOption"
+)
+
+func (f *Fetcher) getIngressRoutes() (map[string]*IngressRoute, error) {
+	ingressRoutes, err := f.traefik.Traefik().V1alpha1().IngressRoutes().Lister().List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*IngressRoute)
+	for _, ingressRoute := range ingressRoutes {
+		var routes []Route
+		for _, route := range ingressRoute.Spec.Routes {
+			services, err := f.getRouteServices(ingressRoute.Namespace, route)
+			if err != nil {
+				return nil, err
+			}
+
+			routes = append(routes, Route{
+				Match:    route.Match,
+				Services: services,
+			})
+		}
+
+		var tls *IngressRouteTLS
+		if ingressRoute.Spec.TLS != nil {
+			tls = &IngressRouteTLS{
+				Domains:    ingressRoute.Spec.TLS.Domains,
+				SecretName: ingressRoute.Spec.TLS.SecretName,
+			}
+			if ingressRoute.Spec.TLS.Options != nil {
+				tls.Options = &TLSOptionRef{
+					Name:      ingressRoute.Spec.TLS.Options.Name,
+					Namespace: ingressRoute.Spec.TLS.Options.Namespace,
+				}
+			}
+		}
+
+		ing := &IngressRoute{
+			ResourceMeta: ResourceMeta{
+				Kind:      ResourceKindIngressRoute,
+				Group:     traefikv1alpha1.GroupName,
+				Name:      ingressRoute.Name,
+				Namespace: ingressRoute.Namespace,
+			},
+			IngressMeta: IngressMeta{
+				Annotations: sanitizeAnnotations(ingressRoute.Annotations),
+			},
+			TLS:      tls,
+			Routes:   routes,
+			Services: getIngressRouteServices(routes),
+		}
+
+		result[ingressKey(ing.ResourceMeta)] = ing
+	}
+
+	return result, nil
+}
+
+func (f *Fetcher) getRouteServices(ingressRouteNamespace string, route traefikv1alpha1.Route) ([]RouteService, error) {
+	var result []RouteService
+	for _, service := range route.Services {
+		if service.Kind != ResourceKindTraefikService {
+			result = append(result, toRouteService(ingressRouteNamespace, &service.LoadBalancerSpec))
+			continue
+		}
+
+		services, err := f.getRouteServicesFromTraefikService(ingressRouteNamespace, service.Namespace, service.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, services...)
+	}
+
+	return result, nil
+}
+
+func (f *Fetcher) getRouteServicesFromTraefikService(parentNamespace, namespace, name string) ([]RouteService, error) {
+	// Here we have to ignore TraefikServices with the cross-provider syntax (containing an @ in the name) as they don't exist in Kubernetes.
+	if strings.Contains(name, "@") {
+		return nil, nil
+	}
+
+	if namespace == "" {
+		namespace = parentNamespace
+	}
+
+	ts, err := f.traefik.Traefik().V1alpha1().TraefikServices().Lister().TraefikServices(namespace).Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if ts.Spec.Mirroring != nil {
+		if ts.Spec.Mirroring.Kind != ResourceKindTraefikService {
+			return []RouteService{toRouteService(namespace, &ts.Spec.Mirroring.LoadBalancerSpec)}, nil
+		}
+
+		services, err := f.getRouteServicesFromTraefikService(namespace, ts.Spec.Mirroring.Namespace, ts.Spec.Mirroring.Name)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO should we handle mirror services?
+		return services, nil
+	}
+
+	// TraefikService should be of type Mirror or Weighted.
+	if ts.Spec.Weighted == nil {
+		return nil, nil
+	}
+
+	var result []RouteService
+	for _, service := range ts.Spec.Weighted.Services {
+		if service.Kind != ResourceKindTraefikService {
+			result = append(result, toRouteService(namespace, &service.LoadBalancerSpec))
+			continue
+		}
+
+		services, err := f.getRouteServicesFromTraefikService(namespace, service.Namespace, service.Name)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, services...)
+	}
+
+	return result, nil
+}
+
+func toRouteService(parentNamespace string, service *traefikv1alpha1.LoadBalancerSpec) RouteService {
+	result := RouteService{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+
+	if service.Namespace == "" {
+		result.Namespace = parentNamespace
+	}
+
+	switch service.Port.Type {
+	case intstr.Int:
+		result.PortNumber = service.Port.IntVal
+	case intstr.String:
+		result.PortName = service.Port.StrVal
+	}
+
+	return result
+}
+
+func getIngressRouteServices(routes []Route) []string {
+	var result []string
+
+	knownServices := make(map[string]struct{})
+
+	for _, r := range routes {
+		for _, s := range r.Services {
+			key := objectKey(s.Name, s.Namespace)
+			if _, exists := knownServices[key]; exists {
+				continue
+			}
+
+			knownServices[key] = struct{}{}
+			result = append(result, key)
+		}
+	}
+
+	return result
+}

--- a/pkg/topology/state/ingress_route_test.go
+++ b/pkg/topology/state/ingress_route_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright (C) 2022 Traefik Labs
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	traefikv1alpha1 "github.com/traefik/hub-agent-kubernetes/pkg/crd/api/traefik/v1alpha1"
+	traefikkubemock "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubemock "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+// Mandatory to be able to parse traefik.containo.us/v1alpha1 resources.
+func init() {
+	err := traefikv1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestFetcher_GetIngressRoutes(t *testing.T) {
+	tests := []struct {
+		desc    string
+		want    map[string]*IngressRoute
+		fixture string
+	}{
+		{
+			desc:    "One service",
+			fixture: "ingress-route-one-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					TLS: &IngressRouteTLS{
+						Domains: []traefikv1alpha1.Domain{
+							{
+								Main: "foo.com",
+								SANs: []string{"bar.foo.com"},
+							},
+						},
+						SecretName: "secret",
+					},
+					Routes: []Route{
+						{
+							Match: "Host(`foo.com`)",
+							Services: []RouteService{
+								{
+									Name:       "service",
+									Namespace:  "ns",
+									PortNumber: 80,
+								},
+							},
+						},
+					},
+					Services: []string{"service@ns"},
+				},
+			},
+		},
+		{
+			desc:    "One service with an internal Traefik service",
+			fixture: "ingress-route-one-internal-traefik-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					Routes: []Route{
+						{
+							Match: "Host(`api.localhost`)",
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:    "One Weighted Traefik service",
+			fixture: "ingress-route-one-weighted-traefik-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					TLS: &IngressRouteTLS{
+						Domains: []traefikv1alpha1.Domain{
+							{
+								Main: "foo.com",
+								SANs: []string{"bar.foo.com"},
+							},
+						},
+						SecretName: "secret",
+					},
+					Routes: []Route{
+						{
+							Match: "Host(`foo.com`)",
+							Services: []RouteService{
+								{
+									Name:       "service1",
+									Namespace:  "ns",
+									PortNumber: 80,
+								},
+								{
+									Name:       "service2",
+									Namespace:  "ns",
+									PortNumber: 80,
+								},
+							},
+						},
+					},
+					Services: []string{"service1@ns", "service2@ns"},
+				},
+			},
+		},
+		{
+			desc:    "One Mirroring Traefik service",
+			fixture: "ingress-route-one-mirroring-traefik-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					TLS: &IngressRouteTLS{
+						Domains: []traefikv1alpha1.Domain{
+							{
+								Main: "foo.com",
+								SANs: []string{"bar.foo.com"},
+							},
+						},
+						SecretName: "secret",
+					},
+					Routes: []Route{
+						{
+							Match: "Host(`foo.com`)",
+							Services: []RouteService{
+								{
+									Name:       "service1",
+									Namespace:  "ns2",
+									PortNumber: 80,
+								},
+							},
+						},
+					},
+					Services: []string{"service1@ns2"},
+				},
+			},
+		},
+		{
+			desc:    "Two Weighted Traefik service",
+			fixture: "ingress-route-two-weighted-traefik-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					TLS: &IngressRouteTLS{
+						Domains: []traefikv1alpha1.Domain{
+							{
+								Main: "foo.com",
+								SANs: []string{"bar.foo.com"},
+							},
+						},
+						SecretName: "secret",
+					},
+					Routes: []Route{
+						{
+							Match: "Host(`foo.com`)",
+							Services: []RouteService{
+								{
+									Name:       "service1",
+									Namespace:  "ns",
+									PortNumber: 80,
+								},
+								{
+									Name:       "service2",
+									Namespace:  "ns2",
+									PortNumber: 80,
+								},
+								{
+									Name:       "service3",
+									Namespace:  "ns2",
+									PortNumber: 80,
+								},
+							},
+						},
+					},
+					Services: []string{"service1@ns", "service2@ns2", "service3@ns2"},
+				},
+			},
+		},
+		{
+			desc:    "Two Mirroring Traefik service",
+			fixture: "ingress-route-two-mirroring-traefik-service.yml",
+			want: map[string]*IngressRoute{
+				"name@ns.ingressroute.traefik.containo.us": {
+					ResourceMeta: ResourceMeta{
+						Kind:      ResourceKindIngressRoute,
+						Group:     traefikv1alpha1.GroupName,
+						Name:      "name",
+						Namespace: "ns",
+					},
+					IngressMeta: IngressMeta{},
+					Routes: []Route{
+						{
+							Match: "Host(`foo.com`)",
+							Services: []RouteService{
+								{
+									Name:       "service",
+									Namespace:  "ns2",
+									PortNumber: 80,
+								},
+							},
+						},
+					},
+					Services: []string{"service@ns2"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			objects := loadK8sObjects(t, "fixtures/ingress-route/"+test.fixture)
+
+			kubeClient := kubemock.NewSimpleClientset()
+			// Faking having Traefik CRDs installed on cluster.
+			kubeClient.Resources = append(kubeClient.Resources, &metav1.APIResourceList{
+				GroupVersion: traefikv1alpha1.SchemeGroupVersion.String(),
+				APIResources: []metav1.APIResource{
+					{Kind: ResourceKindIngressRoute},
+					{Kind: ResourceKindTraefikService},
+					{Kind: ResourceKindTLSOption},
+				},
+			})
+
+			traefikClient := traefikkubemock.NewSimpleClientset(objects...)
+
+			f, err := watchAll(context.Background(), kubeClient, traefikClient, "v1.20.1")
+			require.NoError(t, err)
+
+			got, err := f.getIngressRoutes()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/pkg/topology/state/service_test.go
+++ b/pkg/topology/state/service_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	traefikkubemock "github.com/traefik/hub-agent-kubernetes/pkg/crd/generated/client/traefik/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,8 +85,9 @@ func TestFetcher_GetServices(t *testing.T) {
 	}
 
 	kubeClient := kubemock.NewSimpleClientset(objects...)
+	traefikClient := traefikkubemock.NewSimpleClientset()
 
-	f, err := watchAll(context.Background(), kubeClient, "v1.20.1")
+	f, err := watchAll(context.Background(), kubeClient, traefikClient, "v1.20.1")
 	require.NoError(t, err)
 
 	gotSvcs, err := f.getServices()
@@ -152,8 +154,9 @@ func TestFetcher_GetServicesWithExternalIPs(t *testing.T) {
 	}
 
 	kubeClient := kubemock.NewSimpleClientset(objects...)
+	traefikClient := traefikkubemock.NewSimpleClientset()
 
-	f, err := watchAll(context.Background(), kubeClient, "v1.20.1")
+	f, err := watchAll(context.Background(), kubeClient, traefikClient, "v1.20.1")
 	require.NoError(t, err)
 
 	gotSvcs, err := f.getServices()
@@ -226,7 +229,9 @@ func TestFetcher_GetServiceLogs(t *testing.T) {
 		return true, nil, nil
 	})
 
-	f, err := watchAll(context.Background(), kubeClient, "v1.20.1")
+	traefikClient := traefikkubemock.NewSimpleClientset()
+
+	f, err := watchAll(context.Background(), kubeClient, traefikClient, "v1.20.1")
 	require.NoError(t, err)
 
 	got, err := f.GetServiceLogs(context.Background(), "myns", "myService", 20, 200)
@@ -308,7 +313,9 @@ func TestFetcher_GetServiceLogsHandlesTooManyPods(t *testing.T) {
 		return true, nil, nil
 	})
 
-	f, err := watchAll(context.Background(), kubeClient, "v1.20.1")
+	traefikClient := traefikkubemock.NewSimpleClientset()
+
+	f, err := watchAll(context.Background(), kubeClient, traefikClient, "v1.20.1")
 	require.NoError(t, err)
 
 	got, err := f.GetServiceLogs(context.Background(), "myns", "myService", 2, 200)

--- a/pkg/topology/store/store.go
+++ b/pkg/topology/store/store.go
@@ -115,5 +115,6 @@ func (s *Store) buildPatch(lastTopology []byte, st state.Cluster) ([]byte, []byt
 	if err != nil {
 		return nil, nil, fmt.Errorf("build merge patch: %w", err)
 	}
+
 	return patch, newTopology, nil
 }

--- a/pkg/topology/store/store_test.go
+++ b/pkg/topology/store/store_test.go
@@ -65,6 +65,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": {
 						"annotations":{"key":"value"},
@@ -114,6 +122,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": {
 						"annotations":{"key":"new-value"}
@@ -157,6 +173,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": {
 						"annotations": null
@@ -201,6 +225,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": {
 						"externalPorts": [8080, 8081]
@@ -236,6 +268,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": null
 				}
@@ -285,6 +325,14 @@ func TestStore_Write_fetchAndPatch(t *testing.T) {
 				},
 			},
 			wantPatch: `{
+				"ingresses":{
+					"ingress-1@ns": {
+						"group":"", 
+						"kind":"",
+						"name":"ingress-1",
+						"namespace":"ns"
+					}
+				},
 				"services": {
 					"service-1@ns": null,
 					"service-2@ns": {


### PR DESCRIPTION
### Description

This PR allows agent to send ingresses to hub-topology. 

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>
Co-authored-by: juliens <julien@containo.us>