### PR TITLE
Allow ACP configuration on ingress

### DIFF
--- a/pkg/acp/admission/webhook.go
+++ b/pkg/acp/admission/webhook.go
@@ -211,10 +211,6 @@ func isUsingACP(ar admv1.AdmissionReview) (bool, error) {
 			return false, err
 		}
 		polName = obj.Metadata.Annotations[reviewer.AnnotationHubAuth]
-
-		if obj.Metadata.Labels["app.kubernetes.io/managed-by"] != "traefik-hub" {
-			return false, nil
-		}
 	}
 
 	var oldObj struct {


### PR DESCRIPTION
### Description

This PR allows to configure ACP on ingress.

Co-authored-by: juliens <julien@containo.us>
Co-authored-by: Tom Moulard <tom.moulard@traefik.io>