### PR TITLE
Handle encryption key

### DIFF
--- a/cmd/agent/auth_server_test.go
+++ b/cmd/agent/auth_server_test.go
@@ -20,6 +20,7 @@ package main
 import (
 	"context"
 	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 	corev1 "k8s.io/api/core/v1"

--- a/cmd/agent/auth_server_test.go
+++ b/cmd/agent/auth_server_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2022 Traefik Labs
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubemock "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReadKey(t *testing.T) {
+	cliCtx := &cli.Context{Context: context.Background()}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "hub-secret",
+			Namespace: "default",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"key": []byte("my-key"),
+		},
+	}
+
+	clientSetHub := kubemock.NewSimpleClientset(secret)
+
+	key, err := readKey(cliCtx, clientSetHub)
+	require.NoError(t, err)
+	require.Equal(t, "5e78863ed1ffb9fc66b1d61634b126bf", key)
+}

--- a/cmd/agent/controller_test.go
+++ b/cmd/agent/controller_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (C) 2022 Traefik Labs
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubemock "k8s.io/client-go/kubernetes/fake"
+	ts "k8s.io/client-go/testing"
+)
+
+func TestSetupOIDCSecret(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		objects     []runtime.Object
+		actions     []ts.Action
+		expectedErr assert.ErrorAssertionFunc
+	}{
+		{
+			desc:        "should create secret",
+			expectedErr: assert.NoError,
+			actions: []ts.Action{
+				ts.CreateActionImpl{
+					ActionImpl: ts.ActionImpl{
+						Namespace: "default",
+						Verb:      "create",
+						Resource: schema.GroupVersionResource{
+							Version:  "v1",
+							Resource: "secrets",
+						},
+					},
+					Object: &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "hub-secret",
+							Annotations: map[string]string{
+								"app.kubernetes.io/managed-by": "traefik-hub",
+							},
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: map[string][]byte{
+							"key": []byte("my-token"),
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "with already existing secret",
+			objects: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "hub-secret",
+						Namespace: "default",
+						Annotations: map[string]string{
+							"app.kubernetes.io/managed-by": "traefik-hub",
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"key": []byte("my-token"),
+					},
+				},
+			},
+			actions: []ts.Action{
+				ts.CreateActionImpl{
+					ActionImpl: ts.ActionImpl{
+						Namespace: "default",
+						Verb:      "create",
+						Resource: schema.GroupVersionResource{
+							Version:  "v1",
+							Resource: "secrets",
+						},
+					},
+					Object: &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "hub-secret",
+							Annotations: map[string]string{
+								"app.kubernetes.io/managed-by": "traefik-hub",
+							},
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: map[string][]byte{
+							"key": []byte("my-token"),
+						},
+					},
+				},
+			},
+			expectedErr: assert.NoError,
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			cliCtx := &cli.Context{Context: context.Background()}
+			clientSetHub := kubemock.NewSimpleClientset(test.objects...)
+			err := setupOIDCSecret(cliCtx, clientSetHub, "my-token")
+			test.expectedErr(t, err)
+
+			require.Equal(t, test.actions, clientSetHub.Actions())
+		})
+	}
+}

--- a/pkg/acp/auth/watcher.go
+++ b/pkg/acp/auth/watcher.go
@@ -41,13 +41,13 @@ import (
 // add a parameter to NewWatcher to subscribe only to a subset of events.
 
 type oidcSecret struct {
-	ClientSecret   string
-	SessionKey     string
-	StateCookieKey string
+	ClientSecret string
 }
 
 // Watcher watches access control policy resources and builds configurations out of them.
 type Watcher struct {
+	key string
+
 	configsMu sync.RWMutex
 	configs   map[string]*acp.Config
 	previous  uint64
@@ -61,8 +61,9 @@ type Watcher struct {
 
 // NewWatcher returns a new watcher to track ACP resources. It calls the given Updater when an ACP is modified at most
 // once every throttle.
-func NewWatcher(switcher *HTTPHandlerSwitcher) *Watcher {
+func NewWatcher(switcher *HTTPHandlerSwitcher, key string) *Watcher {
 	return &Watcher{
+		key:      key,
 		configs:  make(map[string]*acp.Config),
 		secrets:  make(map[string]oidcSecret),
 		refresh:  make(chan struct{}, 1),
@@ -138,16 +139,12 @@ func (w *Watcher) populateSecrets() {
 func (w *Watcher) OnAdd(obj interface{}) {
 	switch v := obj.(type) {
 	case *hubv1alpha1.AccessControlPolicy:
-		w.configsMu.Lock()
-		w.configs[v.ObjectMeta.Name] = acp.ConfigFromPolicy(v)
-		w.configsMu.Unlock()
+		w.ConfigFromPolicy(v)
 
 	case *corev1.Secret:
 		w.configsMu.Lock()
 		w.secrets[v.Namespace+"@"+v.Name] = oidcSecret{
-			ClientSecret:   string(v.Data["clientSecret"]),
-			SessionKey:     string(v.Data["sessionKey"]),
-			StateCookieKey: string(v.Data["stateCookieKey"]),
+			ClientSecret: string(v.Data["clientSecret"]),
 		}
 		w.configsMu.Unlock()
 
@@ -169,16 +166,12 @@ func (w *Watcher) OnAdd(obj interface{}) {
 func (w *Watcher) OnUpdate(_, newObj interface{}) {
 	switch v := newObj.(type) {
 	case *hubv1alpha1.AccessControlPolicy:
-		w.configsMu.Lock()
-		w.configs[v.ObjectMeta.Name] = acp.ConfigFromPolicy(v)
-		w.configsMu.Unlock()
+		w.ConfigFromPolicy(v)
 
 	case *corev1.Secret:
 		w.configsMu.Lock()
 		w.secrets[v.Namespace+"@"+v.Name] = oidcSecret{
-			ClientSecret:   string(v.Data["clientSecret"]),
-			SessionKey:     string(v.Data["sessionKey"]),
-			StateCookieKey: string(v.Data["stateCookieKey"]),
+			ClientSecret: string(v.Data["clientSecret"]),
 		}
 		w.configsMu.Unlock()
 
@@ -193,6 +186,21 @@ func (w *Watcher) OnUpdate(_, newObj interface{}) {
 	select {
 	case w.refresh <- struct{}{}:
 	default:
+	}
+}
+
+// ConfigFromPolicy wraps acp.ConfigFromPolicy and stores the OIDC key in the
+// configuration.
+func (w *Watcher) ConfigFromPolicy(policy *hubv1alpha1.AccessControlPolicy) {
+	w.configsMu.Lock()
+	defer w.configsMu.Unlock()
+
+	w.configs[policy.ObjectMeta.Name] = acp.ConfigFromPolicy(policy)
+	if w.configs[policy.ObjectMeta.Name].OIDC != nil {
+		w.configs[policy.ObjectMeta.Name].OIDC.Key = w.key
+	}
+	if w.configs[policy.ObjectMeta.Name].OIDCGoogle != nil {
+		w.configs[policy.ObjectMeta.Name].OIDCGoogle.Key = w.key
 	}
 }
 
@@ -291,25 +299,7 @@ func populateSecrets(config *oidc.Config, secret oidcSecret) error {
 		return errors.New("clientSecret is missing in secret")
 	}
 
-	if secret.SessionKey == "" {
-		return errors.New("sessionKey is missing in secret")
-	}
-
-	if secret.StateCookieKey == "" {
-		return errors.New("stateCookieKey is missing in secret")
-	}
-
 	config.ClientSecret = secret.ClientSecret
-
-	if config.Session == nil {
-		config.Session = &oidc.AuthSession{}
-	}
-	config.Session.Secret = secret.SessionKey
-
-	if config.StateCookie == nil {
-		config.StateCookie = &oidc.AuthStateCookie{}
-	}
-	config.StateCookie.Secret = secret.StateCookieKey
 
 	return nil
 }

--- a/pkg/acp/auth/watcher.go
+++ b/pkg/acp/auth/watcher.go
@@ -139,7 +139,7 @@ func (w *Watcher) populateSecrets() {
 func (w *Watcher) OnAdd(obj interface{}) {
 	switch v := obj.(type) {
 	case *hubv1alpha1.AccessControlPolicy:
-		w.ConfigFromPolicy(v)
+		w.updateConfigFromPolicy(v)
 
 	case *corev1.Secret:
 		w.configsMu.Lock()
@@ -166,7 +166,7 @@ func (w *Watcher) OnAdd(obj interface{}) {
 func (w *Watcher) OnUpdate(_, newObj interface{}) {
 	switch v := newObj.(type) {
 	case *hubv1alpha1.AccessControlPolicy:
-		w.ConfigFromPolicy(v)
+		w.updateConfigFromPolicy(v)
 
 	case *corev1.Secret:
 		w.configsMu.Lock()
@@ -189,9 +189,7 @@ func (w *Watcher) OnUpdate(_, newObj interface{}) {
 	}
 }
 
-// ConfigFromPolicy wraps acp.ConfigFromPolicy and stores the OIDC key in the
-// configuration.
-func (w *Watcher) ConfigFromPolicy(policy *hubv1alpha1.AccessControlPolicy) {
+func (w *Watcher) updateConfigFromPolicy(policy *hubv1alpha1.AccessControlPolicy) {
 	w.configsMu.Lock()
 	defer w.configsMu.Unlock()
 

--- a/pkg/acp/auth/watcher_test.go
+++ b/pkg/acp/auth/watcher_test.go
@@ -64,9 +64,7 @@ func createSecret(namespace, name string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Data: map[string][]byte{
-			"clientSecret":   []byte("1234567890123456"),
-			"sessionKey":     []byte("1234567890123456"),
-			"stateCookieKey": []byte("1234567890123456"),
+			"clientSecret": []byte("1234567890123456"),
 		},
 	}
 }
@@ -83,7 +81,7 @@ func TestWatcher_OnAddOIDC(t *testing.T) {
 	data = fmt.Sprintf(`{"issuer":%q}`, srv.URL)
 
 	switcher := NewHandlerSwitcher()
-	watcher := NewWatcher(switcher)
+	watcher := NewWatcher(switcher, "1234567891234567")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	t.Cleanup(cancel)
@@ -117,7 +115,7 @@ func TestWatcher_OnAddOIDC(t *testing.T) {
 
 func TestWatcher_OnAdd(t *testing.T) {
 	switcher := NewHandlerSwitcher()
-	watcher := NewWatcher(switcher)
+	watcher := NewWatcher(switcher, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	t.Cleanup(cancel)
@@ -186,7 +184,7 @@ func TestWatcher_OnAdd(t *testing.T) {
 
 func TestWatcher_OnUpdate(t *testing.T) {
 	switcher := NewHandlerSwitcher()
-	watcher := NewWatcher(switcher)
+	watcher := NewWatcher(switcher, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	t.Cleanup(cancel)
@@ -239,7 +237,7 @@ func TestWatcher_OnUpdate(t *testing.T) {
 
 func TestWatcher_OnDelete(t *testing.T) {
 	switcher := NewHandlerSwitcher()
-	watcher := NewWatcher(switcher)
+	watcher := NewWatcher(switcher, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	t.Cleanup(cancel)

--- a/pkg/acp/oidc/config.go
+++ b/pkg/acp/oidc/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	LogoutURL   string            `json:"logoutUrl,omitempty"`
 	Scopes      []string          `json:"scopes,omitempty"`
 	AuthParams  map[string]string `json:"authParams,omitempty"`
+	Key         string            `json:"key"`
 	StateCookie *AuthStateCookie  `json:"stateCookie,omitempty"`
 	Session     *AuthSession      `json:"session,omitempty"`
 
@@ -105,26 +106,15 @@ func (cfg *Config) Validate() error {
 		return errors.New("missing client secret")
 	}
 
-	if cfg.Session.Secret == "" {
-		return errors.New("missing session secret")
+	if cfg.Key == "" {
+		return errors.New("missing key")
 	}
 
-	switch len(cfg.Session.Secret) {
+	switch len(cfg.Key) {
 	case 16, 24, 32:
 		break
 	default:
-		return errors.New("session secret must be 16, 24 or 32 characters long")
-	}
-
-	if cfg.StateCookie.Secret == "" {
-		return errors.New("missing state secret")
-	}
-
-	switch len(cfg.StateCookie.Secret) {
-	case 16, 24, 32:
-		break
-	default:
-		return errors.New("state secret must be 16, 24 or 32 characters long")
+		return errors.New("key must be 16, 24 or 32 characters long")
 	}
 
 	if cfg.RedirectURL == "" {
@@ -143,7 +133,6 @@ type SecretReference struct {
 
 // AuthStateCookie carries the state cookie configuration.
 type AuthStateCookie struct {
-	Secret   string `json:"-"`
 	Path     string `json:"path,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	SameSite string `json:"sameSite,omitempty"`
@@ -152,7 +141,6 @@ type AuthStateCookie struct {
 
 // AuthSession carries session and session cookie configuration.
 type AuthSession struct {
-	Secret   string `json:"-"`
 	Path     string `json:"path,omitempty"`
 	Domain   string `json:"domain,omitempty"`
 	SameSite string `json:"sameSite,omitempty"`

--- a/pkg/acp/oidc/config.go
+++ b/pkg/acp/oidc/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	LogoutURL   string            `json:"logoutUrl,omitempty"`
 	Scopes      []string          `json:"scopes,omitempty"`
 	AuthParams  map[string]string `json:"authParams,omitempty"`
-	Key         string            `json:"key"`
+	Key         string            `json:"-"`
 	StateCookie *AuthStateCookie  `json:"stateCookie,omitempty"`
 	Session     *AuthSession      `json:"session,omitempty"`
 

--- a/pkg/acp/oidc/cookie.go
+++ b/pkg/acp/oidc/cookie.go
@@ -19,7 +19,6 @@ package oidc
 
 import (
 	"bytes"
-	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
 	"encoding/json"
@@ -46,19 +45,14 @@ type CookieSessionStore struct {
 }
 
 // NewCookieSessionStore creates a cookie session store.
-func NewCookieSessionStore(name string, cfg *AuthSession, rand Randr, maxSize int) (*CookieSessionStore, error) {
-	block, err := aes.NewCipher([]byte(cfg.Secret))
-	if err != nil {
-		return nil, err
-	}
-
+func NewCookieSessionStore(name string, block cipher.Block, cfg *AuthSession, rand Randr, maxSize int) *CookieSessionStore {
 	return &CookieSessionStore{
 		name:    name,
 		cfg:     cfg,
 		maxSize: maxSize,
 		block:   block,
 		rand:    rand,
-	}, nil
+	}
 }
 
 // Create stores the session data into the request cookies.

--- a/pkg/acp/oidc/cookie_test.go
+++ b/pkg/acp/oidc/cookie_test.go
@@ -18,6 +18,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 package oidc
 
 import (
+	"crypto/aes"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -27,14 +28,15 @@ import (
 )
 
 func TestCookieSessionStore_Delete(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret:   "secret1234567890",
+	block, err := aes.NewCipher([]byte("secret1234567890"))
+	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{
 		Path:     "/",
 		Domain:   "example.com",
 		SameSite: "lax",
 		Secure:   true,
 	}, RandrMock{}, 200)
-	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "http://foo.bar", nil)
 	req.AddCookie(&http.Cookie{
@@ -68,14 +70,15 @@ func TestCookieSessionStore_Delete(t *testing.T) {
 }
 
 func TestCookieSessionStore_RemoveCookieOnlyRemovesOurCookie(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret:   "secret1234567890",
+	block, err := aes.NewCipher([]byte("secret1234567890"))
+	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{
 		Path:     "/",
 		Domain:   "example.com",
 		SameSite: "lax",
 		Secure:   true,
 	}, RandrMock{}, 200)
-	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "http://foo.bar", nil)
 	req.AddCookie(&http.Cookie{
@@ -102,14 +105,15 @@ func TestCookieSessionStore_RemoveCookieOnlyRemovesOurCookie(t *testing.T) {
 }
 
 func TestCookieSessionStore_Create(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret:   "secret1234567890",
+	block, err := aes.NewCipher([]byte("secret1234567890"))
+	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{
 		Path:     "/",
 		Domain:   "example.com",
 		SameSite: "lax",
 		Secure:   true,
 	}, RandrMock{}, 200)
-	require.NoError(t, err)
 
 	sess := SessionData{
 		AccessToken: "test1",
@@ -125,14 +129,15 @@ func TestCookieSessionStore_Create(t *testing.T) {
 }
 
 func TestCookieSessionStore_CreateCanChunkCookies(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret:   "secret1234567890",
+	block, err := aes.NewCipher([]byte("secret1234567890"))
+	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{
 		Path:     "/",
 		Domain:   "example.com",
 		SameSite: "lax",
 		Secure:   true,
 	}, RandrMock{}, 26)
-	require.NoError(t, err)
 
 	sess := SessionData{
 		AccessToken: "test1",
@@ -162,14 +167,15 @@ func TestCookieSessionStore_CreateCanChunkCookies(t *testing.T) {
 }
 
 func TestCookieSessionStore_Update(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret:   "secret1234567890",
+	block, err := aes.NewCipher([]byte("secret1234567890"))
+	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{
 		Path:     "/",
 		Domain:   "example.com",
 		SameSite: "lax",
 		Secure:   true,
 	}, RandrMock{}, 200)
-	require.NoError(t, err)
 
 	sess := SessionData{
 		AccessToken: "test1",
@@ -185,10 +191,10 @@ func TestCookieSessionStore_Update(t *testing.T) {
 }
 
 func TestCookieSessionStore_Get(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret: "secret1234567890",
-	}, RandrMock{}, 200)
+	block, err := aes.NewCipher([]byte("secret1234567890"))
 	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{}, RandrMock{}, 200)
 
 	req := httptest.NewRequest(http.MethodGet, "http://foo.bar", nil)
 	req.AddCookie(&http.Cookie{
@@ -204,10 +210,10 @@ func TestCookieSessionStore_Get(t *testing.T) {
 }
 
 func TestCookieSessionStore_GetHandlesChunkedCookies(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret: "secret1234567890",
-	}, RandrMock{}, 200)
+	block, err := aes.NewCipher([]byte("secret1234567890"))
 	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{}, RandrMock{}, 200)
 
 	req := httptest.NewRequest(http.MethodGet, "http://foo.bar", nil)
 	req.AddCookie(&http.Cookie{
@@ -231,10 +237,10 @@ func TestCookieSessionStore_GetHandlesChunkedCookies(t *testing.T) {
 }
 
 func TestCookieSessionStore_GetReturnsNilIfNoSessionExists(t *testing.T) {
-	store, err := NewCookieSessionStore("test-name", &AuthSession{
-		Secret: "secret1234567890",
-	}, RandrMock{}, 200)
+	block, err := aes.NewCipher([]byte("secret1234567890"))
 	require.NoError(t, err)
+
+	store := NewCookieSessionStore("test-name", block, &AuthSession{}, RandrMock{}, 200)
 
 	req := httptest.NewRequest(http.MethodGet, "http://foo.bar", nil)
 

--- a/pkg/acp/oidc/oidc_test.go
+++ b/pkg/acp/oidc/oidc_test.go
@@ -49,12 +49,6 @@ func TestNewMiddlewareFromSource_ValidatesConfiguration(t *testing.T) {
 				ClientID:     "bar",
 				ClientSecret: "bat",
 				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
 			},
 			wantErr: "validate configuration: missing issuer",
 		},
@@ -65,92 +59,8 @@ func TestNewMiddlewareFromSource_ValidatesConfiguration(t *testing.T) {
 				ClientID:     "",
 				ClientSecret: "bat",
 				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
 			},
 			wantErr: "validate configuration: missing client ID",
-		},
-		{
-			desc: "empty ClientSecret",
-			cfg: &Config{
-				Issuer:       "foo",
-				ClientID:     "bar",
-				ClientSecret: "",
-				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-			},
-			wantErr: "validate configuration: missing client secret",
-		},
-		{
-			desc: "empty Session Secret",
-			cfg: &Config{
-				Issuer:       "foo",
-				ClientID:     "bar",
-				ClientSecret: "bat",
-				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
-				Session: &AuthSession{
-					Secret: "",
-				},
-			},
-			wantErr: "validate configuration: missing session secret",
-		},
-		{
-			desc: "bad size for Session Secret",
-			cfg: &Config{
-				Issuer:       "foo",
-				ClientID:     "bar",
-				ClientSecret: "bat",
-				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
-				Session: &AuthSession{
-					Secret: "foo",
-				},
-			},
-			wantErr: "validate configuration: session secret must be 16, 24 or 32 characters long",
-		},
-		{
-			desc: "empty State Secret",
-			cfg: &Config{
-				Issuer:       "foo",
-				ClientID:     "bar",
-				ClientSecret: "bat",
-				RedirectURL:  "test",
-				StateCookie:  &AuthStateCookie{},
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-			},
-			wantErr: "validate configuration: missing state secret",
-		},
-		{
-			desc: "bad size for State Secret",
-			cfg: &Config{
-				Issuer:       "foo",
-				ClientID:     "bar",
-				ClientSecret: "bat",
-				RedirectURL:  "test",
-				StateCookie: &AuthStateCookie{
-					Secret: "foo",
-				},
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-			},
-			wantErr: "validate configuration: state secret must be 16, 24 or 32 characters long",
 		},
 	}
 
@@ -192,8 +102,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 					"hd": "example.com",
 				},
 				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-					Path:   "/",
+					Path: "/",
 				},
 			},
 			wantStatus:      http.StatusFound,
@@ -209,8 +118,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			cfg: &Config{
 				RedirectURL: "/callback",
 				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-					Path:   "/",
+					Path: "/",
 				},
 			},
 			wantStatus:      http.StatusFound,
@@ -223,8 +131,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			cfg: &Config{
 				RedirectURL: "example.com/callback",
 				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-					Path:   "/",
+					Path: "/",
 				},
 			},
 			wantStatus:      http.StatusFound,
@@ -235,9 +142,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			desc:    "returns unauthorized if method is PUT",
 			request: httptest.NewRequest(http.MethodPut, "/foo", nil),
 			cfg: &Config{
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
+				StateCookie: &AuthStateCookie{},
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -245,9 +150,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			desc:    "returns unauthorized if method is POST",
 			request: httptest.NewRequest(http.MethodPost, "/foo", nil),
 			cfg: &Config{
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
+				StateCookie: &AuthStateCookie{},
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -255,9 +158,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			desc:    "returns unauthorized if method is DELETE",
 			request: httptest.NewRequest(http.MethodDelete, "/foo", nil),
 			cfg: &Config{
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
+				StateCookie: &AuthStateCookie{},
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -265,9 +166,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			desc:    "returns unauthorized if method is PATCH",
 			request: httptest.NewRequest(http.MethodPatch, "/foo", nil),
 			cfg: &Config{
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
+				StateCookie: &AuthStateCookie{},
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -275,9 +174,7 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 			desc:    "returns unauthorized if path is favicon.ico",
 			request: httptest.NewRequest(http.MethodGet, "https://foo.com/favicon.ico", nil),
 			cfg: &Config{
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
+				StateCookie: &AuthStateCookie{},
 			},
 			wantStatus: http.StatusUnauthorized,
 		},
@@ -290,7 +187,6 @@ func TestMiddleware_RedirectsCorrectly(t *testing.T) {
 					"hd": "example.com",
 				},
 				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
 					Path:   "/",
 					Domain: "example.com",
 				},
@@ -384,7 +280,6 @@ func TestMiddleware_ExchangesTokenOnCallback(t *testing.T) {
 		ClientSecret: "client-secret",
 		RedirectURL:  "http://foobar.com/callback",
 		StateCookie: &AuthStateCookie{
-			Secret:   "secret1234567890",
 			Path:     "/",
 			SameSite: "lax",
 			Secure:   true,
@@ -464,12 +359,6 @@ func TestMiddleware_ForwardsCorrectly(t *testing.T) {
 				ClientID:     "clientID",
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
 			},
 			idToken:    "badtoken, very bad token.",
 			wantStatus: http.StatusBadRequest,
@@ -482,12 +371,6 @@ func TestMiddleware_ForwardsCorrectly(t *testing.T) {
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
 				Claims:       "Equals(`group`,`dev`)",
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
 			},
 			idToken:    jwtToken,
 			wantStatus: http.StatusForbidden,
@@ -500,12 +383,6 @@ func TestMiddleware_ForwardsCorrectly(t *testing.T) {
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
 				Claims:       "Equals(`group`,`admin`)",
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
 				ForwardHeaders: map[string]string{
 					"X-App-Group": "group",
 				},
@@ -524,12 +401,6 @@ func TestMiddleware_ForwardsCorrectly(t *testing.T) {
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
 				Claims:       "Equals(`group`,`admin`)",
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
 				ForwardHeaders: map[string]string{
 					"x-App-Group": "group",
 				},
@@ -550,12 +421,6 @@ func TestMiddleware_ForwardsCorrectly(t *testing.T) {
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
 				Claims:       "Equals(`group`,`admin`)",
-				Session: &AuthSession{
-					Secret: "secret1234567890",
-				},
-				StateCookie: &AuthStateCookie{
-					Secret: "secret1234567890",
-				},
 				ForwardHeaders: map[string]string{
 					"x-App-Group": "group",
 				},
@@ -668,8 +533,6 @@ func TestMiddleware_LogsOutCorrectly(t *testing.T) {
 				ClientID:     "clientID",
 				ClientSecret: "secret1234567890",
 				RedirectURL:  "http://foo.com",
-				StateCookie:  &AuthStateCookie{Secret: "secret1234567890"},
-				Session:      &AuthSession{Secret: "secret1234567890"},
 				LogoutURL:    test.logoutURL,
 			}
 
@@ -713,11 +576,11 @@ func buildHandler(t *testing.T) *Handler {
 	require.NoError(t, err)
 
 	return &Handler{
-		name:       "test",
-		stateBlock: stateBlock,
-		rand:       newRandom(),
-		client:     client,
-		verifier:   verifier,
+		name:     "test",
+		block:    stateBlock,
+		rand:     newRandom(),
+		client:   client,
+		verifier: verifier,
 	}
 }
 


### PR DESCRIPTION
### Description

This PR makes the agent able to manage stateCookieKey and sessionKey used in OIDC. This way, it is no longer necessary for the user to define them.

Co-authored-by: Tom Moulard <tom.moulard@traefik.io>