### PR TITLE
fix: catalog status URLs concatenation

### DIFF
--- a/pkg/catalog/admission/webhook_test.go
+++ b/pkg/catalog/admission/webhook_test.go
@@ -120,7 +120,7 @@ func TestHandler_ServeHTTP_createOperation(t *testing.T) {
 			{Op: "replace", Path: "/status", Value: hubv1alpha1.CatalogStatus{
 				Version:  "version-1",
 				SyncedAt: now,
-				URLs:     []string{"https://foo.example.com"},
+				URLs:     "https://foo.example.com",
 				Domains:  []string{"foo.example.com"},
 				SpecHash: "LekmJZ51xaHyapt8obKjf+/lg3M=",
 			}},
@@ -286,7 +286,7 @@ func TestHandler_ServeHTTP_updateOperation(t *testing.T) {
 				Version:  "version-4",
 				SyncedAt: now,
 				Domains:  []string{"foo.example.com"},
-				URLs:     []string{"https://foo.example.com"},
+				URLs:     "https://foo.example.com",
 				SpecHash: "rOG0fFXyK3/sUYGqjggW/ix7rFc=",
 			}},
 		}),

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -19,6 +19,7 @@ package catalog
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	hubv1alpha1 "github.com/traefik/hub-agent-kubernetes/pkg/crd/api/hub/v1alpha1"
@@ -76,7 +77,7 @@ func (e *Catalog) Resource() (*hubv1alpha1.Catalog, error) {
 			Version:  e.Version,
 			SyncedAt: metav1.Now(),
 			Domains:  domains,
-			URLs:     urls,
+			URLs:     strings.Join(urls, ","),
 			SpecHash: specHash,
 		},
 	}, nil

--- a/pkg/catalog/watcher_test.go
+++ b/pkg/catalog/watcher_test.go
@@ -54,7 +54,7 @@ var toUpdate = hubv1alpha1.Catalog{
 	Status: hubv1alpha1.CatalogStatus{
 		Version:  "version-1",
 		SyncedAt: metav1.NewTime(time.Now().Add(-time.Hour)),
-		URLs:     []string{"https://sad-bat-456.hub-traefik.io"},
+		URLs:     "https://sad-bat-456.hub-traefik.io",
 		SpecHash: "yxjMx+3w4R4B4YPzoGkqi/g9rLs=",
 	},
 }
@@ -80,7 +80,7 @@ var toDelete = hubv1alpha1.Catalog{
 	Status: hubv1alpha1.CatalogStatus{
 		Version:  "version-1",
 		SyncedAt: metav1.NewTime(time.Now().Add(-time.Hour)),
-		URLs:     []string{"https://broken-cat-123.hub-traefik.io"},
+		URLs:     "https://broken-cat-123.hub-traefik.io",
 		SpecHash: "7kfh53DLsXumNEaO/nkeVYs/5CI=",
 	},
 }
@@ -141,7 +141,7 @@ func Test_WatcherRun(t *testing.T) {
 			},
 			Status: hubv1alpha1.CatalogStatus{
 				Version:  "version-1",
-				URLs:     []string{"https://hello.example.com"},
+				URLs:     "https://hello.example.com",
 				Domains:  []string{"hello.example.com"},
 				SpecHash: "+MBiHj7QfVFo+CKOe2AdHrOqatM=",
 			},
@@ -153,7 +153,7 @@ func Test_WatcherRun(t *testing.T) {
 			},
 			Status: hubv1alpha1.CatalogStatus{
 				Version:  "version-2",
-				URLs:     []string{"https://majestic-beaver-123.hub-traefik.io"},
+				URLs:     "https://majestic-beaver-123.hub-traefik.io",
 				Domains:  []string{"majestic-beaver-123.hub-traefik.io"},
 				SpecHash: "W1ABIs7KjEa8fb1ErTuS9SK0z6E=",
 			},

--- a/pkg/crd/api/hub/v1alpha1/catalog.go
+++ b/pkg/crd/api/hub/v1alpha1/catalog.go
@@ -31,7 +31,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Catalog defines a catalog.
-// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.status.url`
+// +kubebuilder:printcolumn:name="URLs",type=string,JSONPath=`.status.urls`
 // +kubebuilder:resource:scope=Cluster
 type Catalog struct {
 	metav1.TypeMeta `json:",inline"`
@@ -80,8 +80,8 @@ type CatalogStatus struct {
 	Version  string      `json:"version,omitempty"`
 	SyncedAt metav1.Time `json:"syncedAt,omitempty"`
 
-	// URLs are the URL for accessing the Catalog API.
-	URLs []string `json:"urls"`
+	// URLs are the URLs for accessing the Catalog API.
+	URLs string `json:"urls"`
 
 	// Domains are the domains of the Catalog API.
 	Domains []string `json:"domains"`

--- a/pkg/crd/api/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/crd/api/hub/v1alpha1/zz_generated.deepcopy.go
@@ -391,11 +391,6 @@ func (in *CatalogSpec) DeepCopy() *CatalogSpec {
 func (in *CatalogStatus) DeepCopyInto(out *CatalogStatus) {
 	*out = *in
 	in.SyncedAt.DeepCopyInto(&out.SyncedAt)
-	if in.URLs != nil {
-		in, out := &in.URLs, &out.URLs
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.Domains != nil {
 		in, out := &in.Domains, &out.Domains
 		*out = make([]string, len(*in))


### PR DESCRIPTION
This PR fixes the Catalog CRD so the `Status.URLs` is a string of comma separated URLs. Kubernetes is not able to render array of strings in additional printer columns.