### PR TITLE
feat: expose catalogs with both hub domain and custom domains

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -237,3 +237,6 @@ issues:
     - path: pkg/platform/client_test.go
       linters:
         - gocognit
+    - path: pkg/catalog/watcher_test.go
+      linters:
+        - gocognit

--- a/cmd/agent/controller.go
+++ b/cmd/agent/controller.go
@@ -212,8 +212,7 @@ func setupOIDCSecret(cliCtx *cli.Context, client clientset.Interface, token stri
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hub-secret",
-			// FIXME: replace by a label
-			Annotations: map[string]string{
+			Labels: map[string]string{
 				"app.kubernetes.io/managed-by": "traefik-hub",
 			},
 		},

--- a/cmd/agent/controller.go
+++ b/cmd/agent/controller.go
@@ -212,6 +212,7 @@ func setupOIDCSecret(cliCtx *cli.Context, client clientset.Interface, token stri
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hub-secret",
+			// FIXME: replace by a label
 			Annotations: map[string]string{
 				"app.kubernetes.io/managed-by": "traefik-hub",
 			},

--- a/cmd/agent/controller_test.go
+++ b/cmd/agent/controller_test.go
@@ -55,7 +55,7 @@ func TestSetupOIDCSecret(t *testing.T) {
 					Object: &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "hub-secret",
-							Annotations: map[string]string{
+							Labels: map[string]string{
 								"app.kubernetes.io/managed-by": "traefik-hub",
 							},
 						},
@@ -74,7 +74,7 @@ func TestSetupOIDCSecret(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "hub-secret",
 						Namespace: "default",
-						Annotations: map[string]string{
+						Labels: map[string]string{
 							"app.kubernetes.io/managed-by": "traefik-hub",
 						},
 					},
@@ -97,7 +97,7 @@ func TestSetupOIDCSecret(t *testing.T) {
 					Object: &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "hub-secret",
-							Annotations: map[string]string{
+							Labels: map[string]string{
 								"app.kubernetes.io/managed-by": "traefik-hub",
 							},
 						},

--- a/cmd/agent/webhook_admission.go
+++ b/cmd/agent/webhook_admission.go
@@ -170,7 +170,7 @@ func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *
 		CertSyncInterval:        time.Hour,
 	}
 
-	catalogWatcherCfg := catalog.WatcherConfig{
+	catalogWatcherCfg := &catalog.WatcherConfig{
 		IngressClassName:         cliCtx.String(flagIngressClassName),
 		AgentNamespace:           currentNamespace(),
 		TraefikCatalogEntryPoint: cliCtx.String(flagTraefikCatalogEntryPoint),
@@ -230,7 +230,7 @@ func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *
 	return nil
 }
 
-func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client, topoWatch *topology.Watcher, authServerAddr string, edgeIngressWatcherCfg edgeingress.WatcherConfig, catalogWatcherCfg catalog.WatcherConfig) (acpHdl, edgeIngressHdl, catalogHdl http.Handler, err error) {
+func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client, topoWatch *topology.Watcher, authServerAddr string, edgeIngressWatcherCfg edgeingress.WatcherConfig, catalogWatcherCfg *catalog.WatcherConfig) (acpHdl, edgeIngressHdl, catalogHdl http.Handler, err error) {
 	config, err := kube.InClusterConfigWithRetrier(2)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("create Kubernetes in-cluster configuration: %w", err)

--- a/cmd/agent/webhook_admission.go
+++ b/cmd/agent/webhook_admission.go
@@ -171,12 +171,15 @@ func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *
 	}
 
 	catalogWatcherCfg := catalog.WatcherConfig{
-		CatalogSyncInterval:      time.Minute,
+		IngressClassName:         cliCtx.String(flagIngressClassName),
 		AgentNamespace:           currentNamespace(),
+		TraefikCatalogEntryPoint: cliCtx.String(flagTraefikCatalogEntryPoint),
+		TraefikTunnelEntryPoint:  cliCtx.String(flagTraefikTunnelEntryPoint),
 		DevPortalServiceName:     cliCtx.String(flagDevPortalServiceName),
 		DevPortalPort:            cliCtx.Int(flagDevPortalPort),
-		TraefikCatalogEntryPoint: cliCtx.String(flagTraefikCatalogEntryPoint),
-		IngressClassName:         cliCtx.String(flagIngressClassName),
+		CatalogSyncInterval:      time.Minute,
+		CertSyncInterval:         time.Hour,
+		CertRetryInterval:        time.Minute,
 	}
 
 	acpAdmission, edgeIngressAdmission, catalogAdmission, err := setupAdmissionHandlers(ctx, platformClient, topoWatch, authServerAddr, edgeIngressWatcherCfg, catalogWatcherCfg)

--- a/pkg/catalog/admission/webhook_test.go
+++ b/pkg/catalog/admission/webhook_test.go
@@ -129,7 +129,7 @@ func TestHandler_ServeHTTP_createOperation(t *testing.T) {
 				SyncedAt: now,
 				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com,https://bar.example.com",
 				Domain:   "majestic-beaver-123.hub-traefik.io",
-				SpecHash: "kzeBNy1NCJnw3rhb7XarvvgWloc=",
+				SpecHash: "Sz6cVxZ70Qm0el1CHhSpsbou92U=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{
 						Name:           "whoami",
@@ -310,7 +310,7 @@ func TestHandler_ServeHTTP_updateOperation(t *testing.T) {
 				SyncedAt: now,
 				Domain:   "majestic-beaver-123.hub-traefik.io",
 				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com",
-				SpecHash: "DMuQdfKN8K4d6dEPyQPSnIBBQro=",
+				SpecHash: "rOG0fFXyK3/sUYGqjggW/ix7rFc=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{
 						Name:           "new-whoami",

--- a/pkg/catalog/admission/webhook_test.go
+++ b/pkg/catalog/admission/webhook_test.go
@@ -129,7 +129,7 @@ func TestHandler_ServeHTTP_createOperation(t *testing.T) {
 				SyncedAt: now,
 				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com,https://bar.example.com",
 				Domain:   "majestic-beaver-123.hub-traefik.io",
-				SpecHash: "Sz6cVxZ70Qm0el1CHhSpsbou92U=",
+				SpecHash: "kzeBNy1NCJnw3rhb7XarvvgWloc=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{
 						Name:           "whoami",
@@ -310,7 +310,7 @@ func TestHandler_ServeHTTP_updateOperation(t *testing.T) {
 				SyncedAt: now,
 				Domain:   "majestic-beaver-123.hub-traefik.io",
 				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com",
-				SpecHash: "rOG0fFXyK3/sUYGqjggW/ix7rFc=",
+				SpecHash: "DMuQdfKN8K4d6dEPyQPSnIBBQro=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{
 						Name:           "new-whoami",

--- a/pkg/catalog/admission/webhook_test.go
+++ b/pkg/catalog/admission/webhook_test.go
@@ -88,6 +88,7 @@ func TestHandler_ServeHTTP_createOperation(t *testing.T) {
 		Name:          catalogName,
 		Version:       "version-1",
 		Services:      testCatalogSpec.Services,
+		Domain:        "majestic-beaver-123.hub-traefik.io",
 		CustomDomains: testCatalogSpec.CustomDomains,
 		CreatedAt:     time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond),
 		UpdatedAt:     time.Now().UTC().Truncate(time.Millisecond),
@@ -126,8 +127,8 @@ func TestHandler_ServeHTTP_createOperation(t *testing.T) {
 			{Op: "replace", Path: "/status", Value: hubv1alpha1.CatalogStatus{
 				Version:  "version-1",
 				SyncedAt: now,
-				URLs:     "https://foo.example.com,https://bar.example.com",
-				Domains:  []string{"foo.example.com", "bar.example.com"},
+				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com,https://bar.example.com",
+				Domain:   "majestic-beaver-123.hub-traefik.io",
 				SpecHash: "Sz6cVxZ70Qm0el1CHhSpsbou92U=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{
@@ -266,6 +267,7 @@ func TestHandler_ServeHTTP_updateOperation(t *testing.T) {
 		ClusterID:     "cluster-id",
 		Name:          catalogName,
 		Version:       "version-4",
+		Domain:        "majestic-beaver-123.hub-traefik.io",
 		CustomDomains: newCatalog.Spec.CustomDomains,
 		Services:      newCatalog.Spec.Services,
 		CreatedAt:     time.Now().Add(-time.Hour).UTC().Truncate(time.Millisecond),
@@ -306,8 +308,8 @@ func TestHandler_ServeHTTP_updateOperation(t *testing.T) {
 			{Op: "replace", Path: "/status", Value: hubv1alpha1.CatalogStatus{
 				Version:  "version-4",
 				SyncedAt: now,
-				Domains:  []string{"foo.example.com"},
-				URLs:     "https://foo.example.com",
+				Domain:   "majestic-beaver-123.hub-traefik.io",
+				URLs:     "https://majestic-beaver-123.hub-traefik.io,https://foo.example.com",
 				SpecHash: "rOG0fFXyK3/sUYGqjggW/ix7rFc=",
 				Services: []hubv1alpha1.CatalogServiceStatus{
 					{

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -45,7 +45,7 @@ type Catalog struct {
 // Service is a service within a catalog.
 type Service = hubv1alpha1.CatalogService
 
-// Resource builds the v1alpha1 EdgeIngress resource.
+// Resource builds the v1alpha1 Catalog resource.
 func (c *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error) {
 	var serviceStatuses []hubv1alpha1.CatalogServiceStatus
 	for _, svc := range c.Services {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -46,9 +46,9 @@ type Catalog struct {
 type Service = hubv1alpha1.CatalogService
 
 // Resource builds the v1alpha1 EdgeIngress resource.
-func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error) {
+func (c *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error) {
 	var serviceStatuses []hubv1alpha1.CatalogServiceStatus
-	for _, svc := range e.Services {
+	for _, svc := range c.Services {
 		svc := svc
 
 		openAPISpecURL := svc.OpenAPISpecURL
@@ -64,8 +64,8 @@ func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error
 	}
 
 	spec := hubv1alpha1.CatalogSpec{
-		CustomDomains: e.CustomDomains,
-		Services:      e.Services,
+		CustomDomains: c.CustomDomains,
+		Services:      c.Services,
 	}
 
 	specHash, err := spec.Hash()
@@ -73,8 +73,8 @@ func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error
 		return nil, fmt.Errorf("compute spec hash: %w", err)
 	}
 
-	urls := []string{"https://" + e.Domain}
-	for _, customDomain := range e.CustomDomains {
+	urls := []string{"https://" + c.Domain}
+	for _, customDomain := range c.CustomDomains {
 		urls = append(urls, "https://"+customDomain)
 	}
 
@@ -83,12 +83,12 @@ func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error
 			APIVersion: "hub.traefik.io/v1alpha1",
 			Kind:       "Catalog",
 		},
-		ObjectMeta: metav1.ObjectMeta{Name: e.Name},
+		ObjectMeta: metav1.ObjectMeta{Name: c.Name},
 		Spec:       spec,
 		Status: hubv1alpha1.CatalogStatus{
-			Version:  e.Version,
+			Version:  c.Version,
 			SyncedAt: metav1.Now(),
-			Domain:   e.Domain,
+			Domain:   c.Domain,
 			URLs:     strings.Join(urls, ","),
 			SpecHash: specHash,
 			Services: serviceStatuses,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -73,17 +73,9 @@ func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error
 		return nil, fmt.Errorf("compute spec hash: %w", err)
 	}
 
-	var domains []string
-	var urls []string
+	urls := []string{"https://" + e.Domain}
 	for _, customDomain := range e.CustomDomains {
-		domains = append(domains, customDomain)
 		urls = append(urls, "https://"+customDomain)
-	}
-
-	// As soon as a custom domain is provided we stop proposing the hub generated domain.
-	if len(domains) == 0 {
-		domains = []string{e.Domain}
-		urls = append(urls, "https://"+e.Domain)
 	}
 
 	return &hubv1alpha1.Catalog{
@@ -96,7 +88,7 @@ func (e *Catalog) Resource(oasRegistry OASRegistry) (*hubv1alpha1.Catalog, error
 		Status: hubv1alpha1.CatalogStatus{
 			Version:  e.Version,
 			SyncedAt: metav1.Now(),
-			Domains:  domains,
+			Domain:   e.Domain,
 			URLs:     strings.Join(urls, ","),
 			SpecHash: specHash,
 			Services: serviceStatuses,

--- a/pkg/catalog/mock_gen_test.go
+++ b/pkg/catalog/mock_gen_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/traefik/hub-agent-kubernetes/pkg/edgeingress"
 )
 
 // platformClientMock mock of PlatformClient.
@@ -112,8 +113,239 @@ func (_c *platformClientGetCatalogsCall) OnGetCatalogs() *platformClientGetCatal
 	return _c.Parent.OnGetCatalogs()
 }
 
+func (_c *platformClientGetCatalogsCall) OnGetCertificateByDomains(domains []string) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomains(domains)
+}
+
+func (_c *platformClientGetCatalogsCall) OnGetWildcardCertificate() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificate()
+}
+
 func (_c *platformClientGetCatalogsCall) OnGetCatalogsRaw() *platformClientGetCatalogsCall {
 	return _c.Parent.OnGetCatalogsRaw()
+}
+
+func (_c *platformClientGetCatalogsCall) OnGetCertificateByDomainsRaw(domains interface{}) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomainsRaw(domains)
+}
+
+func (_c *platformClientGetCatalogsCall) OnGetWildcardCertificateRaw() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificateRaw()
+}
+
+func (_m *platformClientMock) GetCertificateByDomains(_ context.Context, domains []string) (edgeingress.Certificate, error) {
+	_ret := _m.Called(domains)
+
+	if _rf, ok := _ret.Get(0).(func([]string) (edgeingress.Certificate, error)); ok {
+		return _rf(domains)
+	}
+
+	_ra0, _ := _ret.Get(0).(edgeingress.Certificate)
+	_rb1 := _ret.Error(1)
+
+	return _ra0, _rb1
+}
+
+func (_m *platformClientMock) OnGetCertificateByDomains(domains []string) *platformClientGetCertificateByDomainsCall {
+	return &platformClientGetCertificateByDomainsCall{Call: _m.Mock.On("GetCertificateByDomains", domains), Parent: _m}
+}
+
+func (_m *platformClientMock) OnGetCertificateByDomainsRaw(domains interface{}) *platformClientGetCertificateByDomainsCall {
+	return &platformClientGetCertificateByDomainsCall{Call: _m.Mock.On("GetCertificateByDomains", domains), Parent: _m}
+}
+
+type platformClientGetCertificateByDomainsCall struct {
+	*mock.Call
+	Parent *platformClientMock
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Panic(msg string) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Panic(msg)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Once() *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Once()
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Twice() *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Twice()
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Times(i int) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Times(i)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) WaitUntil(w <-chan time.Time) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.WaitUntil(w)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) After(d time.Duration) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.After(d)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Run(fn func(args mock.Arguments)) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Run(fn)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) Maybe() *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Maybe()
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) TypedReturns(a edgeingress.Certificate, b error) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Return(a, b)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) ReturnsFn(fn func([]string) (edgeingress.Certificate, error)) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Return(fn)
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) TypedRun(fn func([]string)) *platformClientGetCertificateByDomainsCall {
+	_c.Call = _c.Call.Run(func(args mock.Arguments) {
+		_domains, _ := args.Get(0).([]string)
+		fn(_domains)
+	})
+	return _c
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetCatalogs() *platformClientGetCatalogsCall {
+	return _c.Parent.OnGetCatalogs()
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetCertificateByDomains(domains []string) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomains(domains)
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetWildcardCertificate() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificate()
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetCatalogsRaw() *platformClientGetCatalogsCall {
+	return _c.Parent.OnGetCatalogsRaw()
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetCertificateByDomainsRaw(domains interface{}) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomainsRaw(domains)
+}
+
+func (_c *platformClientGetCertificateByDomainsCall) OnGetWildcardCertificateRaw() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificateRaw()
+}
+
+func (_m *platformClientMock) GetWildcardCertificate(_ context.Context) (edgeingress.Certificate, error) {
+	_ret := _m.Called()
+
+	if _rf, ok := _ret.Get(0).(func() (edgeingress.Certificate, error)); ok {
+		return _rf()
+	}
+
+	_ra0, _ := _ret.Get(0).(edgeingress.Certificate)
+	_rb1 := _ret.Error(1)
+
+	return _ra0, _rb1
+}
+
+func (_m *platformClientMock) OnGetWildcardCertificate() *platformClientGetWildcardCertificateCall {
+	return &platformClientGetWildcardCertificateCall{Call: _m.Mock.On("GetWildcardCertificate"), Parent: _m}
+}
+
+func (_m *platformClientMock) OnGetWildcardCertificateRaw() *platformClientGetWildcardCertificateCall {
+	return &platformClientGetWildcardCertificateCall{Call: _m.Mock.On("GetWildcardCertificate"), Parent: _m}
+}
+
+type platformClientGetWildcardCertificateCall struct {
+	*mock.Call
+	Parent *platformClientMock
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Panic(msg string) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Panic(msg)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Once() *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Once()
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Twice() *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Twice()
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Times(i int) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Times(i)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) WaitUntil(w <-chan time.Time) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.WaitUntil(w)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) After(d time.Duration) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.After(d)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Run(fn func(args mock.Arguments)) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Run(fn)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) Maybe() *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Maybe()
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) TypedReturns(a edgeingress.Certificate, b error) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Return(a, b)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) ReturnsFn(fn func() (edgeingress.Certificate, error)) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Return(fn)
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) TypedRun(fn func()) *platformClientGetWildcardCertificateCall {
+	_c.Call = _c.Call.Run(func(args mock.Arguments) {
+		fn()
+	})
+	return _c
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetCatalogs() *platformClientGetCatalogsCall {
+	return _c.Parent.OnGetCatalogs()
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetCertificateByDomains(domains []string) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomains(domains)
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetWildcardCertificate() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificate()
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetCatalogsRaw() *platformClientGetCatalogsCall {
+	return _c.Parent.OnGetCatalogsRaw()
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetCertificateByDomainsRaw(domains interface{}) *platformClientGetCertificateByDomainsCall {
+	return _c.Parent.OnGetCertificateByDomainsRaw(domains)
+}
+
+func (_c *platformClientGetWildcardCertificateCall) OnGetWildcardCertificateRaw() *platformClientGetWildcardCertificateCall {
+	return _c.Parent.OnGetWildcardCertificateRaw()
 }
 
 // oasRegistryMock mock of OASRegistry.

--- a/pkg/catalog/testdata/new-catalog/want.catalogs.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.catalogs.yaml
@@ -1,0 +1,35 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: Catalog
+metadata:
+  name: new-catalog
+spec:
+  customDomains:
+    - "hello.example.com"
+    - "welcome.example.com"
+  services:
+    - pathPrefix: /whoami-1
+      name: whoami-1
+      namespace: default
+      port: 80
+    - pathPrefix: /whoami-2
+      name: whoami-2
+      namespace: default
+      port: 8080
+    - pathPrefix: /whoami-3
+      name: whoami-3
+      namespace: my-ns
+      port: 8080
+status:
+  version: version-1
+  domain: majestic-beaver-123.hub-traefik.io
+  urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com,https://welcome.example.com"
+  specHash: "Bf0YL8pBl7nfwDsoszFlKcWa6zA="
+  services:
+    - name: whoami-1
+      namespace: default
+    - name: whoami-2
+      namespace: default
+      openApiSpecUrl: "http://whoami-2.default.svc:8080/spec.json"
+    - name: whoami-3
+      namespace: my-ns
+

--- a/pkg/catalog/testdata/new-catalog/want.catalogs.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.catalogs.yaml
@@ -23,7 +23,7 @@ status:
   version: version-1
   domain: majestic-beaver-123.hub-traefik.io
   urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com,https://welcome.example.com"
-  specHash: "Bf0YL8pBl7nfwDsoszFlKcWa6zA="
+  specHash: "HbhRY3LGNcaqKPJ+wmFo7lUwj5I="
   services:
     - name: whoami-1
       namespace: default

--- a/pkg/catalog/testdata/new-catalog/want.edge-ingresses.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.edge-ingresses.yaml
@@ -1,0 +1,15 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: EdgeIngress
+metadata:
+  name: new-catalog-4277033999-portal
+  namespace: agent-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+spec:
+  service:
+    name: dev-portal-service-name
+    port: 8080

--- a/pkg/catalog/testdata/new-catalog/want.ingresses.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -32,7 +33,10 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
-
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 ---
 
 # Ingress for hub domain in the my-ns namespace.
@@ -48,6 +52,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -62,7 +67,10 @@ spec:
                 name: whoami-3
                 port:
                   number: 8080
-
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 ---
 
 # Ingress for custom domains in the default namespace.
@@ -78,6 +86,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -116,7 +125,11 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
-
+  tls:
+    - secretName: hub-certificate-custom-domains-4277033999
+      hosts:
+        - hello.example.com
+        - welcome.example.com
 ---
 # Ingress for custom domains in the my-ns namespace.
 apiVersion: networking.k8s.io/v1
@@ -131,6 +144,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -155,3 +169,8 @@ spec:
                 name: whoami-3
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-4277033999
+      hosts:
+        - hello.example.com
+        - welcome.example.com

--- a/pkg/catalog/testdata/new-catalog/want.ingresses.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.ingresses.yaml
@@ -1,0 +1,157 @@
+# Ingress for hub domain in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: new-catalog-4277033999-hub
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+
+# Ingress for hub domain in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: new-catalog-4277033999-hub
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-3
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-3
+                port:
+                  number: 8080
+
+---
+
+# Ingress for custom domains in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: new-catalog-4277033999
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+    - host: welcome.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+# Ingress for custom domains in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: new-catalog-4277033999
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-3
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-3
+                port:
+                  number: 8080
+    - host: welcome.example.com
+      http:
+        paths:
+          - path: /whoami-3
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-3
+                port:
+                  number: 8080

--- a/pkg/catalog/testdata/new-catalog/want.secrets.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: agent-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
 type: kubernetes.io/tls
 data:
@@ -18,7 +18,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-4277033999
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -72,7 +72,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-4277033999
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/catalog/testdata/new-catalog/want.secrets.yaml
+++ b/pkg/catalog/testdata/new-catalog/want.secrets.yaml
@@ -1,0 +1,84 @@
+# Secret for hub domain in the agent namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: agent-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-4277033999
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-4277033999
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: new-catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private

--- a/pkg/catalog/testdata/updated-catalog-service-added/catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/catalogs.yaml
@@ -1,0 +1,20 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  customDomains:
+    - "hello.example.com"
+  services:
+    - pathPrefix: /whoami-1
+      name: whoami-1
+      namespace: default
+      port: 80
+status:
+  version: version-1
+  domain: majestic-beaver-123.hub-traefik.io
+  urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
+  specHash: "3oh1v5LUNVT5Xh01nzFNNyCTCTc="
+  services:
+    - name: whoami-1
+      namespace: default

--- a/pkg/catalog/testdata/updated-catalog-service-added/ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -25,9 +26,12 @@ spec:
                 name: whoami-1
                 port:
                   number: 80
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 
 ---
-
 # Ingress for custom domains in the default namespace.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -41,6 +45,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -55,3 +60,7 @@ spec:
                 name: whoami-1
                 port:
                   number: 80
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com

--- a/pkg/catalog/testdata/updated-catalog-service-added/ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/ingresses.yaml
@@ -1,0 +1,57 @@
+# Ingress for hub domain in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+
+---
+
+# Ingress for custom domains in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80

--- a/pkg/catalog/testdata/updated-catalog-service-added/secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: agent-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
 type: kubernetes.io/tls
 data:
@@ -18,7 +18,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/catalog/testdata/updated-catalog-service-added/secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/secrets.yaml
@@ -1,0 +1,48 @@
+# Secret for hub domain in the agent namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: agent-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.catalogs.yaml
@@ -1,0 +1,26 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  customDomains:
+    - "hello.example.com"
+  services:
+    - pathPrefix: /whoami-1
+      name: whoami-1
+      namespace: default
+      port: 8080
+    - pathPrefix: /whoami-2
+      name: whoami-2
+      namespace: my-ns
+      port: 8080
+status:
+  version: version-2
+  domain: majestic-beaver-123.hub-traefik.io
+  urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
+  specHash: "Bg3/XcEio7xIzORqDdFdM0iC3ww="
+  services:
+    - name: whoami-1
+      namespace: default
+    - name: whoami-2
+      namespace: my-ns

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.catalogs.yaml
@@ -18,7 +18,7 @@ status:
   version: version-2
   domain: majestic-beaver-123.hub-traefik.io
   urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
-  specHash: "Bg3/XcEio7xIzORqDdFdM0iC3ww="
+  specHash: "ehn0ZtUOngXxSesVYqRCB54fjvU="
   services:
     - name: whoami-1
       namespace: default

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.edge-ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.edge-ingresses.yaml
@@ -1,0 +1,15 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: EdgeIngress
+metadata:
+  name: catalog-1680030486-portal
+  namespace: agent-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+spec:
+  service:
+    name: dev-portal-service-name
+    port: 8080

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.ingresses.yaml
@@ -1,0 +1,114 @@
+# Ingress for hub domain in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 8080
+
+---
+# Ingress for hub domain in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+# Ingress for custom domains in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 8080
+
+---
+# Ingress for custom domains in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -25,7 +26,10 @@ spec:
                 name: whoami-1
                 port:
                   number: 8080
-
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 ---
 # Ingress for hub domain in the my-ns namespace.
 apiVersion: networking.k8s.io/v1
@@ -40,6 +44,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -54,7 +59,10 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
-
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 ---
 # Ingress for custom domains in the default namespace.
 apiVersion: networking.k8s.io/v1
@@ -69,6 +77,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -83,6 +92,10 @@ spec:
                 name: whoami-1
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com
 
 ---
 # Ingress for custom domains in the my-ns namespace.
@@ -98,6 +111,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -112,3 +126,7 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.secrets.yaml
@@ -1,0 +1,84 @@
+# Secret for hub domain in the agent namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: agent-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private

--- a/pkg/catalog/testdata/updated-catalog-service-added/want.secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-added/want.secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: agent-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
 type: kubernetes.io/tls
 data:
@@ -18,7 +18,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -72,7 +72,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/catalogs.yaml
@@ -1,0 +1,33 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  customDomains:
+    - "hello.example.com"
+  services:
+    - pathPrefix: /whoami-1
+      name: whoami-1
+      namespace: default
+      port: 80
+    - pathPrefix: /whoami-2
+      name: whoami-2
+      namespace: default
+      port: 8080
+    - pathPrefix: /whoami-3
+      name: whoami-3
+      namespace: my-ns
+      port: 8080
+status:
+  version: version-1
+  domain: majestic-beaver-123.hub-traefik.io
+  urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
+  specHash: "3oh1v5LUNVT5Xh01nzFNNyCTCTc="
+  services:
+    - name: whoami-1
+      namespace: default
+    - name: whoami-2
+      namespace: default
+      openApiSpecUrl: "http://whoami-2.default.svc:8080/spec.json"
+    - name: whoami-3
+      namespace: my-ns

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -32,6 +33,10 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 
 ---
 
@@ -48,6 +53,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -62,6 +68,10 @@ spec:
                 name: whoami-3
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 
 ---
 
@@ -78,6 +88,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -99,6 +110,10 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com
 
 ---
 # Ingress for custom domains in the my-ns namespace.
@@ -114,6 +129,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -128,3 +144,7 @@ spec:
                 name: whoami-3
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/ingresses.yaml
@@ -1,0 +1,130 @@
+# Ingress for hub domain in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+
+# Ingress for hub domain in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-3
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-3
+                port:
+                  number: 8080
+
+---
+
+# Ingress for custom domains in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 80
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+# Ingress for custom domains in the my-ns namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: my-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-3
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-3
+                port:
+                  number: 8080

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/secrets.yaml
@@ -1,0 +1,84 @@
+# Secret for hub domain in the agent namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: agent-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the my-ns namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: my-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: agent-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
 type: kubernetes.io/tls
 data:
@@ -18,7 +18,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -54,7 +54,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -72,7 +72,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: my-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.catalogs.yaml
@@ -1,0 +1,30 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: Catalog
+metadata:
+  name: catalog
+spec:
+  customDomains:
+    - "hello.example.com"
+  services:
+    - pathPrefix: /whoami-1
+      name: whoami-1
+      namespace: default
+      port: 8080
+      openApiSpecUrl: "http://hello.example.com/spec.json"
+    - pathPrefix: /whoami-2
+      name: whoami-2
+      namespace: default
+      port: 8080
+status:
+  version: version-2
+  domain: majestic-beaver-123.hub-traefik.io
+  urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
+  specHash: "gwhlYvNUpeYPiZErVbrYEmacRkg="
+  services:
+    - name: whoami-1
+      namespace: default
+      openApiSpecUrl: "http://hello.example.com/spec.json"
+    - name: whoami-2
+      namespace: default
+      openApiSpecUrl: "http://whoami-2.default.svc:8080/spec.json"
+

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.catalogs.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.catalogs.yaml
@@ -19,7 +19,7 @@ status:
   version: version-2
   domain: majestic-beaver-123.hub-traefik.io
   urls: "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com"
-  specHash: "gwhlYvNUpeYPiZErVbrYEmacRkg="
+  specHash: "JiNFWTDh2QN2UXI2axjtY21Zpf0="
   services:
     - name: whoami-1
       namespace: default

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.edge-ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.edge-ingresses.yaml
@@ -1,0 +1,15 @@
+apiVersion: hub.traefik.io/v1alpha1
+kind: EdgeIngress
+metadata:
+  name: catalog-1680030486-portal
+  namespace: agent-ns
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+spec:
+  service:
+    name: dev-portal-service-name
+    port: 8080

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.ingresses.yaml
@@ -1,0 +1,70 @@
+# Ingress for hub domain in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486-hub
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: majestic-beaver-123.hub-traefik.io
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 8080
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080
+
+---
+# Ingress for custom domains in the default namespace.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalog-1680030486
+  namespace: default
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+  labels:
+    app.kubernetes.io/managed-by: traefik-hub
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
+spec:
+  ingressClassName: ingress-class
+  rules:
+    - host: hello.example.com
+      http:
+        paths:
+          - path: /whoami-1
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-1
+                port:
+                  number: 8080
+          - path: /whoami-2
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami-2
+                port:
+                  number: 8080

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.ingresses.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.ingresses.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: tunnel-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -32,6 +33,10 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate
+      hosts:
+        - majestic-beaver-123.hub-traefik.io
 
 ---
 # Ingress for custom domains in the default namespace.
@@ -47,6 +52,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: traefik-hub
   annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: catalog-entrypoint
 spec:
   ingressClassName: ingress-class
@@ -68,3 +74,7 @@ spec:
                 name: whoami-2
                 port:
                   number: 8080
+  tls:
+    - secretName: hub-certificate-custom-domains-1680030486
+      hosts:
+        - hello.example.com

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.secrets.yaml
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: agent-ns
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
 type: kubernetes.io/tls
 data:
@@ -18,7 +18,7 @@ kind: Secret
 metadata:
   name: hub-certificate
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: hub-certificate-custom-domains-1680030486
   namespace: default
-  annotations:
+  labels:
     app.kubernetes.io/managed-by: traefik-hub
   ownerReferences:
     - apiVersion: hub.traefik.io/v1alpha1

--- a/pkg/catalog/testdata/updated-catalog-service-deleted/want.secrets.yaml
+++ b/pkg/catalog/testdata/updated-catalog-service-deleted/want.secrets.yaml
@@ -1,0 +1,48 @@
+# Secret for hub domain in the agent namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: agent-ns
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for hub domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private
+
+---
+# Secret for custom domains in the default namespace.
+apiVersion: core.k8s.io/v1
+kind: Secret
+metadata:
+  name: hub-certificate-custom-domains-1680030486
+  namespace: default
+  annotations:
+    app.kubernetes.io/managed-by: traefik-hub
+  ownerReferences:
+    - apiVersion: hub.traefik.io/v1alpha1
+      kind: Catalog
+      name: catalog
+type: kubernetes.io/tls
+data:
+  tls.crt: Y2VydA== # cert
+  tls.key: cHJpdmF0ZQ== # private

--- a/pkg/catalog/watcher.go
+++ b/pkg/catalog/watcher.go
@@ -77,7 +77,7 @@ type WatcherConfig struct {
 
 // Watcher watches hub Catalogs and sync them with the cluster.
 type Watcher struct {
-	config WatcherConfig
+	config *WatcherConfig
 
 	wildCardCert   edgeingress.Certificate
 	wildCardCertMu sync.RWMutex
@@ -93,7 +93,7 @@ type Watcher struct {
 }
 
 // NewWatcher returns a new Watcher.
-func NewWatcher(client PlatformClient, oasRegistry OASRegistry, kubeClientSet clientset.Interface, kubeInformer informers.SharedInformerFactory, hubClientSet hubclientset.Interface, hubInformer hubinformer.SharedInformerFactory, config WatcherConfig) *Watcher {
+func NewWatcher(client PlatformClient, oasRegistry OASRegistry, kubeClientSet clientset.Interface, kubeInformer informers.SharedInformerFactory, hubClientSet hubclientset.Interface, hubInformer hubinformer.SharedInformerFactory, config *WatcherConfig) *Watcher {
 	return &Watcher{
 		config: config,
 
@@ -243,7 +243,7 @@ func (w *Watcher) upsertSecret(ctx context.Context, cert edgeingress.Certificate
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
-				Annotations: map[string]string{
+				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "traefik-hub",
 				},
 			},
@@ -584,7 +584,7 @@ func (w *Watcher) upsertIngress(ctx context.Context, ingress *netv1.Ingress) err
 	return nil
 }
 
-// cleanupIngresses deletes ingresses from namespaces that are no longer referenced in the catalog.
+// cleanupIngresses deletes the ingresses from namespaces that are no longer referenced in the catalog.
 func (w *Watcher) cleanupIngresses(ctx context.Context, catalog *hubv1alpha1.Catalog) error {
 	managedByHub, err := labels.NewRequirement("app.kubernetes.io/managed-by", selection.Equals, []string{"traefik-hub"})
 	if err != nil {

--- a/pkg/catalog/watcher.go
+++ b/pkg/catalog/watcher.go
@@ -430,7 +430,7 @@ func (w *Watcher) buildIngress(namespace, name string, catalog *hubv1alpha1.Cata
 	}
 
 	var rules []netv1.IngressRule
-	for _, domain := range catalog.Status.Domains {
+	for _, domain := range catalog.Spec.CustomDomains {
 		rules = append(rules, netv1.IngressRule{
 			Host: domain,
 			IngressRuleValue: netv1.IngressRuleValue{

--- a/pkg/catalog/watcher_test.go
+++ b/pkg/catalog/watcher_test.go
@@ -214,7 +214,7 @@ func Test_WatcherRun(t *testing.T) {
 				TypedReturns("").
 				Maybe()
 
-			w := NewWatcher(client, oasRegistry, kubeClientSet, kubeInformer, hubClientSet, hubInformer, WatcherConfig{
+			w := NewWatcher(client, oasRegistry, kubeClientSet, kubeInformer, hubClientSet, hubInformer, &WatcherConfig{
 				IngressClassName:         "ingress-class",
 				AgentNamespace:           "agent-ns",
 				TraefikCatalogEntryPoint: "catalog-entrypoint",
@@ -266,9 +266,7 @@ func Test_WatcherRun(t *testing.T) {
 				namespaceSecretList, err = kubeClientSet.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
 				require.NoError(t, err)
 
-				for _, secret := range namespaceSecretList.Items {
-					secrets = append(secrets, secret)
-				}
+				secrets = append(secrets, namespaceSecretList.Items...)
 			}
 
 			assert.ElementsMatch(t, wantCatalogs, catalogs)
@@ -317,7 +315,7 @@ func TestWatcher_Run_OASRegistryUpdated(t *testing.T) {
 	oasRegistry := newOasRegistryMock(t)
 	oasRegistry.OnUpdated().TypedReturns(oasCh)
 
-	w := NewWatcher(client, oasRegistry, kubeClientSet, kubeInformer, hubClientSet, hubInformer, WatcherConfig{
+	w := NewWatcher(client, oasRegistry, kubeClientSet, kubeInformer, hubClientSet, hubInformer, &WatcherConfig{
 		IngressClassName:         "ingress-class",
 		TraefikCatalogEntryPoint: "entrypoint",
 		// Very high interval to prevent the ticker from firing.

--- a/pkg/catalog/watcher_test.go
+++ b/pkg/catalog/watcher_test.go
@@ -18,7 +18,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 package catalog
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -32,9 +34,9 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/informers"
 	kubemock "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/pointer"
 )
 
 func Test_WatcherRun(t *testing.T) {
@@ -51,21 +53,21 @@ func Test_WatcherRun(t *testing.T) {
 		},
 	}
 
-	pathType := netv1.PathTypePrefix
 	namespaces := []string{"default", "my-ns"}
 
 	tests := []struct {
 		desc             string
 		platformCatalogs []Catalog
-		clusterCatalogs  []runtime.Object
-		clusterIngresses []runtime.Object
 
-		wantCatalogs      []hubv1alpha1.Catalog
-		wantIngresses     []netv1.Ingress
-		wantEdgeIngresses []hubv1alpha1.EdgeIngress
+		clusterCatalogs  string
+		clusterIngresses string
+
+		wantCatalogs      string
+		wantIngresses     string
+		wantEdgeIngresses string
 	}{
 		{
-			desc: "new catalog present on the platform",
+			desc: "new catalog present on the platform needs to be created on the cluster",
 			platformCatalogs: []Catalog{
 				{
 					Name:          "new-catalog",
@@ -79,203 +81,12 @@ func Test_WatcherRun(t *testing.T) {
 					},
 				},
 			},
-			wantCatalogs: []hubv1alpha1.Catalog{
-				{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "hub.traefik.io/v1alpha1",
-						Kind:       "Catalog",
-					},
-					ObjectMeta: metav1.ObjectMeta{Name: "new-catalog"},
-					Spec: hubv1alpha1.CatalogSpec{
-						CustomDomains: []string{"hello.example.com", "welcome.example.com"},
-						Services: []hubv1alpha1.CatalogService{
-							{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 80},
-							{PathPrefix: "/whoami-2", Name: "whoami-2", Namespace: "default", Port: 8080},
-							{PathPrefix: "/whoami-3", Name: "whoami-3", Namespace: "my-ns", Port: 8080},
-						},
-					},
-					Status: hubv1alpha1.CatalogStatus{
-						Version:  "version-1",
-						Domain:   "majestic-beaver-123.hub-traefik.io",
-						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com,https://welcome.example.com",
-						SpecHash: "HbhRY3LGNcaqKPJ+wmFo7lUwj5I=",
-						Services: []hubv1alpha1.CatalogServiceStatus{
-							{Name: "whoami-1", Namespace: "default"},
-							{Name: "whoami-2", Namespace: "default", OpenAPISpecURL: "http://whoami-2.default.svc:8080/spec.json"},
-							{Name: "whoami-3", Namespace: "my-ns"},
-						},
-					},
-				},
-			},
-			wantEdgeIngresses: []hubv1alpha1.EdgeIngress{
-				{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "hub.traefik.io/v1alpha1",
-						Kind:       "EdgeIngress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-catalog-portal-4277033999",
-						Namespace: "agent-ns",
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "new-catalog",
-						}},
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-					},
-					Spec: hubv1alpha1.EdgeIngressSpec{
-						Service: hubv1alpha1.EdgeIngressService{
-							Name: "dev-portal-service-name",
-							Port: 8080,
-						},
-					},
-				},
-			},
-			wantIngresses: []netv1.Ingress{
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "networking.k8s.io/v1",
-						APIVersion: "Ingress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-catalog-4277033999",
-						Namespace: "default",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-						Annotations: map[string]string{
-							"traefik.ingress.kubernetes.io/router.entrypoints": "entrypoint",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "new-catalog",
-						}},
-					},
-					Spec: netv1.IngressSpec{
-						IngressClassName: pointer.StringPtr("ingress-class"),
-						Rules: []netv1.IngressRule{
-							{
-								Host: "hello.example.com",
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{{
-											Path:     "/whoami-1",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-1",
-													Port: netv1.ServiceBackendPort{Number: 80},
-												},
-											},
-										}, {
-											Path:     "/whoami-2",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-2",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										}},
-									},
-								},
-							},
-							{
-								Host: "welcome.example.com",
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{{
-											Path:     "/whoami-1",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-1",
-													Port: netv1.ServiceBackendPort{Number: 80},
-												},
-											},
-										}, {
-											Path:     "/whoami-2",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-2",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										}},
-									},
-								},
-							},
-						},
-					},
-				},
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "networking.k8s.io/v1",
-						APIVersion: "Ingress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-catalog-4277033999",
-						Namespace: "my-ns",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-						Annotations: map[string]string{
-							"traefik.ingress.kubernetes.io/router.entrypoints": "entrypoint",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "new-catalog",
-						}},
-					},
-					Spec: netv1.IngressSpec{
-						IngressClassName: pointer.StringPtr("ingress-class"),
-						Rules: []netv1.IngressRule{
-							{
-								Host: "hello.example.com",
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{{
-											Path:     "/whoami-3",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-3",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										}},
-									},
-								},
-							},
-							{
-								Host: "welcome.example.com",
-								IngressRuleValue: netv1.IngressRuleValue{
-									HTTP: &netv1.HTTPIngressRuleValue{
-										Paths: []netv1.HTTPIngressPath{{
-											Path:     "/whoami-3",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-3",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										}},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			wantCatalogs:      "testdata/new-catalog/want.catalogs.yaml",
+			wantIngresses:     "testdata/new-catalog/want.ingresses.yaml",
+			wantEdgeIngresses: "testdata/new-catalog/want.edge-ingresses.yaml",
 		},
 		{
-			desc: "catalog updated",
+			desc: "a catalog has been updated on the platform: last service from a namespace deleted",
 			platformCatalogs: []Catalog{
 				{
 					Name:          "catalog",
@@ -288,185 +99,31 @@ func Test_WatcherRun(t *testing.T) {
 					},
 				},
 			},
-			clusterCatalogs: []runtime.Object{
-				&hubv1alpha1.Catalog{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "hub.traefik.io/v1alpha1",
-						Kind:       "Catalog",
-					},
-					ObjectMeta: metav1.ObjectMeta{Name: "catalog"},
-					Spec: hubv1alpha1.CatalogSpec{
-						CustomDomains: []string{"hello.example.com"},
-						Services: []hubv1alpha1.CatalogService{
-							{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 80},
-							{PathPrefix: "/whoami-2", Name: "whoami-2", Namespace: "default", Port: 8080},
-							{PathPrefix: "/whoami-3", Name: "whoami-3", Namespace: "my-ns", Port: 8080},
-						},
-					},
-					Status: hubv1alpha1.CatalogStatus{
-						Version:  "version-1",
-						Domain:   "majestic-beaver-123.hub-traefik.io",
-						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com",
-						SpecHash: "3oh1v5LUNVT5Xh01nzFNNyCTCTc=",
-						Services: []hubv1alpha1.CatalogServiceStatus{
-							{Name: "whoami-1", Namespace: "default"},
-							{Name: "whoami-2", Namespace: "default", OpenAPISpecURL: "http://whoami-2.default.svc:8080/spec.json"},
-							{Name: "whoami-3", Namespace: "my-ns"},
-						},
-					},
-				},
-			},
-			clusterIngresses: []runtime.Object{
-				&netv1.Ingress{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "networking.k8s.io/v1",
-						APIVersion: "Ingress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "catalog-1680030486",
-						Namespace: "default",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-						Annotations: map[string]string{
-							"traefik.ingress.kubernetes.io/router.entrypoints": "entrypoint",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "catalog",
-						}},
-					},
-				},
-				&netv1.Ingress{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "networking.k8s.io/v1",
-						APIVersion: "Ingress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "catalog-1680030486",
-						Namespace: "my-ns",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-						Annotations: map[string]string{
-							"traefik.ingress.kubernetes.io/router.entrypoints": "entrypoint",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "catalog",
-						}},
-					},
-				},
-			},
-			wantCatalogs: []hubv1alpha1.Catalog{
+			clusterCatalogs:   "testdata/updated-catalog-service-deleted/catalogs.yaml",
+			clusterIngresses:  "testdata/updated-catalog-service-deleted/ingresses.yaml",
+			wantCatalogs:      "testdata/updated-catalog-service-deleted/want.catalogs.yaml",
+			wantEdgeIngresses: "testdata/updated-catalog-service-deleted/want.edge-ingresses.yaml",
+			wantIngresses:     "testdata/updated-catalog-service-deleted/want.ingresses.yaml",
+		},
+		{
+			desc: "a catalog has been updated on the platform: new service in new namespace added",
+			platformCatalogs: []Catalog{
 				{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "hub.traefik.io/v1alpha1",
-						Kind:       "Catalog",
-					},
-					ObjectMeta: metav1.ObjectMeta{Name: "catalog"},
-					Spec: hubv1alpha1.CatalogSpec{
-						CustomDomains: []string{"hello.example.com"},
-						Services: []hubv1alpha1.CatalogService{
-							{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 8080, OpenAPISpecURL: "http://hello.example.com/spec.json"},
-							{PathPrefix: "/whoami-2", Name: "whoami-2", Namespace: "default", Port: 8080},
-						},
-					},
-					Status: hubv1alpha1.CatalogStatus{
-						Version:  "version-2",
-						Domain:   "majestic-beaver-123.hub-traefik.io",
-						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com",
-						SpecHash: "JiNFWTDh2QN2UXI2axjtY21Zpf0=",
-						Services: []hubv1alpha1.CatalogServiceStatus{
-							{Name: "whoami-1", Namespace: "default", OpenAPISpecURL: "http://hello.example.com/spec.json"},
-							{Name: "whoami-2", Namespace: "default", OpenAPISpecURL: "http://whoami-2.default.svc:8080/spec.json"},
-						},
+					Name:          "catalog",
+					Version:       "version-2",
+					Domain:        "majestic-beaver-123.hub-traefik.io",
+					CustomDomains: []string{"hello.example.com"},
+					Services: []Service{
+						{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 8080},
+						{PathPrefix: "/whoami-2", Name: "whoami-2", Namespace: "my-ns", Port: 8080},
 					},
 				},
 			},
-			wantEdgeIngresses: []hubv1alpha1.EdgeIngress{
-				{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "hub.traefik.io/v1alpha1",
-						Kind:       "EdgeIngress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "catalog-portal-1680030486",
-						Namespace: "agent-ns",
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "catalog",
-						}},
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-					},
-					Spec: hubv1alpha1.EdgeIngressSpec{
-						Service: hubv1alpha1.EdgeIngressService{
-							Name: "dev-portal-service-name",
-							Port: 8080,
-						},
-					},
-				},
-			},
-			wantIngresses: []netv1.Ingress{
-				{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "networking.k8s.io/v1",
-						APIVersion: "Ingress",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "catalog-1680030486",
-						Namespace: "default",
-						Labels: map[string]string{
-							"app.kubernetes.io/managed-by": "traefik-hub",
-						},
-						Annotations: map[string]string{
-							"traefik.ingress.kubernetes.io/router.entrypoints": "entrypoint",
-						},
-						OwnerReferences: []metav1.OwnerReference{{
-							APIVersion: "hub.traefik.io/v1alpha1",
-							Kind:       "Catalog",
-							Name:       "catalog",
-						}},
-					},
-					Spec: netv1.IngressSpec{
-						IngressClassName: pointer.StringPtr("ingress-class"),
-						Rules: []netv1.IngressRule{{
-							Host: "hello.example.com",
-							IngressRuleValue: netv1.IngressRuleValue{
-								HTTP: &netv1.HTTPIngressRuleValue{
-									Paths: []netv1.HTTPIngressPath{
-										{
-											Path:     "/whoami-1",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-1",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										},
-										{
-											Path:     "/whoami-2",
-											PathType: &pathType,
-											Backend: netv1.IngressBackend{
-												Service: &netv1.IngressServiceBackend{
-													Name: "whoami-2",
-													Port: netv1.ServiceBackendPort{Number: 8080},
-												},
-											},
-										},
-									},
-								},
-							},
-						}},
-					},
-				},
-			},
+			clusterCatalogs:   "testdata/updated-catalog-service-added/catalogs.yaml",
+			clusterIngresses:  "testdata/updated-catalog-service-added/ingresses.yaml",
+			wantCatalogs:      "testdata/updated-catalog-service-added/want.catalogs.yaml",
+			wantEdgeIngresses: "testdata/updated-catalog-service-added/want.edge-ingresses.yaml",
+			wantIngresses:     "testdata/updated-catalog-service-added/want.ingresses.yaml",
 		},
 	}
 
@@ -474,11 +131,26 @@ func Test_WatcherRun(t *testing.T) {
 		test := test
 
 		t.Run(test.desc, func(t *testing.T) {
-			kubeObjects := test.clusterIngresses
+			wantIngresses := loadFixtures[netv1.Ingress](t, test.wantIngresses)
+			wantEdgeIngresses := loadFixtures[hubv1alpha1.EdgeIngress](t, test.wantEdgeIngresses)
+			wantCatalogs := loadFixtures[hubv1alpha1.Catalog](t, test.wantCatalogs)
+
+			clusterIngresses := loadFixtures[netv1.Ingress](t, test.clusterIngresses)
+			clusterCatalogs := loadFixtures[hubv1alpha1.Catalog](t, test.clusterCatalogs)
+
+			var kubeObjects []runtime.Object
 			kubeObjects = append(kubeObjects, services...)
+			for _, clusterIngress := range clusterIngresses {
+				kubeObjects = append(kubeObjects, clusterIngress.DeepCopy())
+			}
+
+			var hubObjects []runtime.Object
+			for _, clusterCatalog := range clusterCatalogs {
+				hubObjects = append(hubObjects, clusterCatalog.DeepCopy())
+			}
 
 			kubeClientSet := kubemock.NewSimpleClientset(kubeObjects...)
-			hubClientSet := hubkubemock.NewSimpleClientset(test.clusterCatalogs...)
+			hubClientSet := hubkubemock.NewSimpleClientset(hubObjects...)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
@@ -510,7 +182,6 @@ func Test_WatcherRun(t *testing.T) {
 			oasRegistry.OnUpdated().TypedReturns(oasCh)
 
 			// We are not interested in the output of this function.
-
 			oasRegistry.
 				OnGetURL("whoami-2", "default").
 				TypedReturns("http://whoami-2.default.svc:8080/spec.json").
@@ -525,7 +196,8 @@ func Test_WatcherRun(t *testing.T) {
 				AgentNamespace:           "agent-ns",
 				DevPortalServiceName:     "dev-portal-service-name",
 				IngressClassName:         "ingress-class",
-				TraefikCatalogEntryPoint: "entrypoint",
+				TraefikCatalogEntryPoint: "catalog-entrypoint",
+				TraefikTunnelEntryPoint:  "tunnel-entrypoint",
 				DevPortalPort:            8080,
 			})
 
@@ -557,9 +229,9 @@ func Test_WatcherRun(t *testing.T) {
 			edgeIngresses, err := hubClientSet.HubV1alpha1().EdgeIngresses("agent-ns").List(ctx, metav1.ListOptions{})
 			require.NoError(t, err)
 
-			assert.ElementsMatch(t, test.wantCatalogs, catalogs)
-			assert.ElementsMatch(t, test.wantIngresses, ingresses)
-			assert.ElementsMatch(t, test.wantEdgeIngresses, edgeIngresses.Items)
+			assert.ElementsMatch(t, wantCatalogs, catalogs)
+			assert.ElementsMatch(t, wantIngresses, ingresses)
+			assert.ElementsMatch(t, wantEdgeIngresses, edgeIngresses.Items)
 		})
 	}
 }
@@ -608,4 +280,30 @@ func TestWatcher_Run_OASRegistryUpdated(t *testing.T) {
 	})
 
 	w.Run(ctx)
+}
+
+func loadFixtures[T any](t *testing.T, path string) []T {
+	t.Helper()
+
+	if path == "" {
+		return []T{}
+	}
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(b), 1000)
+
+	var objects []T
+
+	for {
+		var object T
+		if decoder.Decode(&object) != nil {
+			break
+		}
+
+		objects = append(objects, object)
+	}
+
+	return objects
 }

--- a/pkg/catalog/watcher_test.go
+++ b/pkg/catalog/watcher_test.go
@@ -70,6 +70,7 @@ func Test_WatcherRun(t *testing.T) {
 				{
 					Name:          "new-catalog",
 					Version:       "version-1",
+					Domain:        "majestic-beaver-123.hub-traefik.io",
 					CustomDomains: []string{"hello.example.com", "welcome.example.com"},
 					Services: []Service{
 						{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 80},
@@ -95,8 +96,8 @@ func Test_WatcherRun(t *testing.T) {
 					},
 					Status: hubv1alpha1.CatalogStatus{
 						Version:  "version-1",
-						Domains:  []string{"hello.example.com", "welcome.example.com"},
-						URLs:     "https://hello.example.com,https://welcome.example.com",
+						Domain:   "majestic-beaver-123.hub-traefik.io",
+						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com,https://welcome.example.com",
 						SpecHash: "HbhRY3LGNcaqKPJ+wmFo7lUwj5I=",
 						Services: []hubv1alpha1.CatalogServiceStatus{
 							{Name: "whoami-1", Namespace: "default"},
@@ -279,6 +280,7 @@ func Test_WatcherRun(t *testing.T) {
 				{
 					Name:          "catalog",
 					Version:       "version-2",
+					Domain:        "majestic-beaver-123.hub-traefik.io",
 					CustomDomains: []string{"hello.example.com"},
 					Services: []Service{
 						{PathPrefix: "/whoami-1", Name: "whoami-1", Namespace: "default", Port: 8080, OpenAPISpecURL: "http://hello.example.com/spec.json"},
@@ -303,8 +305,8 @@ func Test_WatcherRun(t *testing.T) {
 					},
 					Status: hubv1alpha1.CatalogStatus{
 						Version:  "version-1",
-						Domains:  []string{"hello.example.com"},
-						URLs:     "https://hello.example.com",
+						Domain:   "majestic-beaver-123.hub-traefik.io",
+						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com",
 						SpecHash: "3oh1v5LUNVT5Xh01nzFNNyCTCTc=",
 						Services: []hubv1alpha1.CatalogServiceStatus{
 							{Name: "whoami-1", Namespace: "default"},
@@ -374,8 +376,8 @@ func Test_WatcherRun(t *testing.T) {
 					},
 					Status: hubv1alpha1.CatalogStatus{
 						Version:  "version-2",
-						Domains:  []string{"hello.example.com"},
-						URLs:     "https://hello.example.com",
+						Domain:   "majestic-beaver-123.hub-traefik.io",
+						URLs:     "https://majestic-beaver-123.hub-traefik.io,https://hello.example.com",
 						SpecHash: "JiNFWTDh2QN2UXI2axjtY21Zpf0=",
 						Services: []hubv1alpha1.CatalogServiceStatus{
 							{Name: "whoami-1", Namespace: "default", OpenAPISpecURL: "http://hello.example.com/spec.json"},

--- a/pkg/crd/api/hub/v1alpha1/catalog.go
+++ b/pkg/crd/api/hub/v1alpha1/catalog.go
@@ -86,8 +86,8 @@ type CatalogStatus struct {
 	// URLs are the URLs for accessing the Catalog API.
 	URLs string `json:"urls"`
 
-	// Domains are the domains of the Catalog API.
-	Domains []string `json:"domains"`
+	// Domain is the hub generated domain of the Catalog API.
+	Domain string `json:"domain"`
 
 	// DevPortalDomain is the domain for accessing the dev portal.
 	DevPortalDomain string `json:"devPortalDomain"`

--- a/pkg/crd/api/hub/v1alpha1/catalog.go
+++ b/pkg/crd/api/hub/v1alpha1/catalog.go
@@ -50,7 +50,7 @@ type Catalog struct {
 type CatalogSpec struct {
 	// CustomDomains are the custom domains under which the API will be exposed.
 	// +optional
-	CustomDomains []string `yaml:"customDomains,omitempty"`
+	CustomDomains []string `json:"customDomains,omitempty"`
 	// Services are the list of Services available in the Catalog.
 	Services []CatalogService `json:"services,omitempty"`
 }

--- a/pkg/crd/api/hub/v1alpha1/catalog.go
+++ b/pkg/crd/api/hub/v1alpha1/catalog.go
@@ -50,7 +50,7 @@ type Catalog struct {
 type CatalogSpec struct {
 	// CustomDomains are the custom domains under which the API will be exposed.
 	// +optional
-	CustomDomains []string `json:"customDomains,omitempty"`
+	CustomDomains []string `yaml:"customDomains,omitempty"`
 	// Services are the list of Services available in the Catalog.
 	Services []CatalogService `json:"services,omitempty"`
 }

--- a/pkg/crd/api/hub/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/crd/api/hub/v1alpha1/zz_generated.deepcopy.go
@@ -407,11 +407,6 @@ func (in *CatalogSpec) DeepCopy() *CatalogSpec {
 func (in *CatalogStatus) DeepCopyInto(out *CatalogStatus) {
 	*out = *in
 	in.SyncedAt.DeepCopyInto(&out.SyncedAt)
-	if in.Domains != nil {
-		in, out := &in.Domains, &out.Domains
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	if in.Services != nil {
 		in, out := &in.Services, &out.Services
 		*out = make([]CatalogServiceStatus, len(*in))

--- a/pkg/edgeingress/watcher.go
+++ b/pkg/edgeingress/watcher.go
@@ -103,6 +103,7 @@ func (w *Watcher) Run(ctx context.Context) {
 		log.Error().Err(err).Msg("Unable to synchronize certificates with platform")
 		certSyncInterval = time.After(w.config.CertRetryInterval)
 	}
+	w.syncEdgeIngresses(ctxSync)
 	cancel()
 
 	for {

--- a/pkg/edgeingress/watcher.go
+++ b/pkg/edgeingress/watcher.go
@@ -419,7 +419,7 @@ func (w *Watcher) upsertSecret(ctx context.Context, cert Certificate, name, name
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
-				Annotations: map[string]string{
+				Labels: map[string]string{
 					"app.kubernetes.io/managed-by": "traefik-hub",
 				},
 			},

--- a/pkg/edgeingress/watcher_test.go
+++ b/pkg/edgeingress/watcher_test.go
@@ -42,7 +42,7 @@ var toUpdate = hubv1alpha1.EdgeIngress{
 		Name:      "toUpdate",
 		Namespace: "default",
 		UID:       "uid",
-		Annotations: map[string]string{
+		Labels: map[string]string{
 			"app.kubernetes.io/managed-by": "traefik-hub",
 		},
 	},
@@ -65,7 +65,7 @@ var toDelete = hubv1alpha1.EdgeIngress{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "toDelete",
 		Namespace: "default",
-		Annotations: map[string]string{
+		Labels: map[string]string{
 			"app.kubernetes.io/managed-by": "traefik-hub",
 		},
 	},


### PR DESCRIPTION
This PR updates the Catalog syncing process to expose catalogs with both hub domain and custom domains.
It also handles a certificates/secrets synchronization mechanism.

Co-authored-by: Harold Ozouf <harold.ozouf@gmail.com>