### PR TITLE
feat: rename default catalog entrypoint to websecure

### DIFF
--- a/cmd/agent/webhook_admission.go
+++ b/cmd/agent/webhook_admission.go
@@ -127,7 +127,7 @@ func admissionFlags() []cli.Flag {
 			Name:    flagTraefikCatalogEntryPoint,
 			Usage:   "The entry point used by Traefik to expose catalog APIs",
 			EnvVars: []string{strcase.ToSNAKE(flagTraefikCatalogEntryPoint)},
-			Value:   "traefikhub-catalog",
+			Value:   "websecure",
 		},
 		&cli.StringFlag{
 			Name:    flagTraefikTunnelEntryPoint,

--- a/pkg/crd/api/hub/v1alpha1/catalog.go
+++ b/pkg/crd/api/hub/v1alpha1/catalog.go
@@ -90,6 +90,7 @@ type CatalogStatus struct {
 	Domain string `json:"domain"`
 
 	// DevPortalDomain is the domain for accessing the dev portal.
+	// +optional
 	DevPortalDomain string `json:"devPortalDomain"`
 
 	// SpecHash is a hash representing the CatalogSpec


### PR DESCRIPTION
This PR changes the default entrypoint to use for exposing the catalog API. The new entrypoint is `websecure`.

This PR also adds the missing optional tag on top of the `DevPortalDomain` (set asynchronously after the EdgeIngress got created).