### PR TITLE
fix: remove portal build from multi-arch dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DOCKER_BUILD_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 DOCKER_IMAGE_TAG ?= $(if $(TAG_NAME),$(TAG_NAME),latest)
 OUTPUT := $(if $(OUTPUT),$(OUTPUT),$(BIN_NAME))
 
-default: clean lint test build
+default: clean build-portal lint test build
 
 lint:
 	golangci-lint run
@@ -22,10 +22,10 @@ lint:
 clean:
 	rm -rf cover.out
 
-test: clean build-portal
+test: clean
 	go test -v -race -cover ./...
 
-build: clean build-portal
+build: clean
 	@echo Version: $(VERSION) $(BUILD_DATE)
 	CGO_ENABLED=0 go build -v -trimpath -ldflags '-X "github.com/traefik/hub-agent-kubernetes/pkg/version.date=${BUILD_DATE}" -X "github.com/traefik/hub-agent-kubernetes/pkg/version.version=${VERSION}" -X "github.com/traefik/hub-agent-kubernetes/pkg/version.commit=${SHA}"' -o ${OUTPUT} ${MAIN_DIRECTORY}
 

--- a/buildx.Dockerfile
+++ b/buildx.Dockerfile
@@ -1,25 +1,4 @@
 # syntax=docker/dockerfile:1.2
-# Portal UI dependencies
-FROM node:18-alpine AS portal-ui-deps
-
-WORKDIR /app
-
-COPY portal/package.json portal/yarn.lock ./
-
-ENV NODE_ENV=production
-RUN yarn install --frozen-lockfile --production
-
-# Portal UI build
-FROM node:18-alpine AS portal-ui-builder
-
-WORKDIR /app
-
-ENV NODE_ENV=production
-COPY --from=portal-ui-deps /app/node_modules ./node_modules
-COPY portal .
-
-RUN NODE_OPTIONS=--max-old-space-size=2048 yarn build
-
 # Go mod
 FROM --platform=$BUILDPLATFORM golang:1.19-alpine AS gomod
 
@@ -40,7 +19,6 @@ RUN apk --update upgrade \
     && update-ca-certificates
 
 COPY --from=gomod /go/pkg/ /go/pkg/
-COPY --from=portal-ui-builder /app/dist ./portal/dist
 COPY . .
 
 ARG TARGETPLATFORM

--- a/portal/buildx.Dockerfile
+++ b/portal/buildx.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY package.json yarn.lock ./
 
-RUN yarn install
+RUN yarn install --frozen-lockfile --production
 
 # Portal UI build
 FROM node:18-alpine AS portal-ui-builder


### PR DESCRIPTION
This PR removes the portal ui build from the multi-arch Dockerfile. Doing the yarn install for every platform was pointless as it just generate the same file over and over, no matter the platform. 

The `build-portal` target is now run on `make`, no longer on `make build` and no longer in the buildx.Dockerfile.