### PR TITLE
Fix current namespace detection

### DIFF
--- a/pkg/acp/config.go
+++ b/pkg/acp/config.go
@@ -358,7 +358,7 @@ func currentNamespace() string {
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
 		return ns
 	}
-	if data, err := os.ReadFile("/var/run/kubeInformer/kubernetes.io/serviceaccount/namespace"); err == nil {
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); ns != "" {
 			return ns
 		}


### PR DESCRIPTION
This pull request fixes the current namespace detection used to read the `hub-secret` when creating the ACP config from a policy.

Co-authored-by: Antoine Couchard <antoine.couchard@traefik.io>