### PR TITLE
fix: api management watchers when feature available

### DIFF
--- a/cmd/agent/controller.go
+++ b/cmd/agent/controller.go
@@ -129,7 +129,7 @@ func (c controllerCmd) run(cliCtx *cli.Context) error {
 		return fmt.Errorf("build platform client: %w", err)
 	}
 
-	configWatcher := platform.NewConfigWatcher(15*time.Minute, platformClient)
+	configWatcher := platform.NewConfigWatcher(time.Minute, platformClient)
 
 	heartbeater := heartbeat.NewHeartbeater(platformClient)
 

--- a/cmd/agent/controller.go
+++ b/cmd/agent/controller.go
@@ -191,7 +191,7 @@ func (c controllerCmd) run(cliCtx *cli.Context) error {
 	})
 
 	group.Go(func() error {
-		errWh := webhookAdmission(ctx, cliCtx, platformClient)
+		errWh := webhookAdmission(ctx, cliCtx, platformClient, configWatcher)
 		if errWh != nil {
 			log.Error().Err(errWh).Msg("webhook stopped")
 		}

--- a/cmd/agent/webhook_admission.go
+++ b/cmd/agent/webhook_admission.go
@@ -59,6 +59,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/strings/slices"
 )
 
 const (
@@ -73,6 +74,8 @@ const (
 	flagDevPortalServiceName              = "dev-portal.service-name"
 	flagDevPortalPort                     = "dev-portal.port"
 )
+
+const apiManagementFeature = "api-management"
 
 func devPortalFlags() []cli.Flag {
 	return []cli.Flag{
@@ -144,7 +147,7 @@ func admissionFlags() []cli.Flag {
 	}
 }
 
-func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *platform.Client) error {
+func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *platform.Client, cfgWatcher *platform.ConfigWatcher) error {
 	var (
 		listenAddr     = cliCtx.String(flagACPServerListenAddr)
 		certFile       = cliCtx.String(flagACPServerCertificate)
@@ -191,7 +194,7 @@ func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *
 		CertRetryInterval:       time.Minute,
 	}
 
-	acpAdmission, edgeIngressAdmission, apiAdmission, err := setupAdmissionHandlers(ctx, platformClient, authServerAddr, edgeIngressWatcherCfg, portalWatcherCfg, gatewayWatcherCfg)
+	acpAdmission, edgeIngressAdmission, apiAdmission, err := setupAdmissionHandlers(ctx, platformClient, authServerAddr, edgeIngressWatcherCfg, portalWatcherCfg, gatewayWatcherCfg, cfgWatcher)
 	if err != nil {
 		return fmt.Errorf("create admission handler: %w", err)
 	}
@@ -245,7 +248,7 @@ func webhookAdmission(ctx context.Context, cliCtx *cli.Context, platformClient *
 	return nil
 }
 
-func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client, authServerAddr string, edgeIngressWatcherCfg edgeingress.WatcherConfig, portalWatcherCfg *api.WatcherPortalConfig, gatewayWatcherCfg *api.WatcherGatewayConfig) (acpHandler, edgeIngressHandler, apiHandler http.Handler, err error) {
+func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client, authServerAddr string, edgeIngressWatcherCfg edgeingress.WatcherConfig, portalWatcherCfg *api.WatcherPortalConfig, gatewayWatcherCfg *api.WatcherGatewayConfig, cfgWatcher *platform.ConfigWatcher) (acpHandler, edgeIngressHandler, apiHandler http.Handler, err error) {
 	config, err := kube.InClusterConfigWithRetrier(2)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("create Kubernetes in-cluster configuration: %w", err)
@@ -287,12 +290,12 @@ func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client
 		return nil, nil, nil, fmt.Errorf("start kube informer: %w", err)
 	}
 
-	apiAvailable, err := isAPIAvailable(kubeClientSet)
+	apiManagementCRDs, err := hasAPIManagementCRDs(kubeClientSet)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("API available: %w", err)
 	}
 
-	err = startHubInformer(ctx, hubInformer, ingClassWatcher, acpEventHandler, apiAvailable)
+	err = startHubInformer(ctx, hubInformer, ingClassWatcher, acpEventHandler, apiManagementCRDs)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("start kube informer: %w", err)
 	}
@@ -307,21 +310,14 @@ func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client
 	go acpWatcher.Run(ctx)
 	go ingressUpdater.Run(ctx)
 	go edgeIngressWatcher.Run(ctx)
-	if apiAvailable {
-		watcherPortal := api.NewWatcherPortal(platformClient, kubeClientSet, kubeInformer, hubClientSet, hubInformer, portalWatcherCfg)
-		go watcherPortal.Run(ctx)
 
-		gatewayWatcher := api.NewWatcherGateway(platformClient, kubeClientSet, kubeInformer, hubClientSet, hubInformer, traefikClientSet, gatewayWatcherCfg)
-		go gatewayWatcher.Run(ctx)
-
-		watcherAPI := api.NewWatcherAPI(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
-		go watcherAPI.Run(ctx)
-
-		watcherCollection := api.NewWatcherCollection(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
-		go watcherCollection.Run(ctx)
-
-		watcherAccess := api.NewWatcherAccess(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
-		go watcherAccess.Run(ctx)
+	if apiManagementCRDs {
+		if err = setupAPIManagementWatcher(ctx,
+			platformClient, kubeClientSet, hubClientSet,
+			traefikClientSet, kubeInformer, hubInformer,
+			portalWatcherCfg, gatewayWatcherCfg, cfgWatcher); err != nil {
+			return nil, nil, nil, fmt.Errorf("setup API management watcher: %w", err)
+		}
 	}
 
 	polGetter := reviewer.NewPolGetter(hubInformer)
@@ -335,7 +331,7 @@ func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client
 		traefikReviewer,
 	}
 
-	if apiAvailable {
+	if apiManagementCRDs {
 		rev := []apiadmission.Reviewer{
 			apireviewer.NewAPI(platformClient),
 			apireviewer.NewCollection(platformClient),
@@ -347,6 +343,56 @@ func setupAdmissionHandlers(ctx context.Context, platformClient *platform.Client
 	}
 
 	return admission.NewHandler(reviewers, traefikReviewer), edgeadmission.NewHandler(platformClient), apiHandler, nil
+}
+
+func setupAPIManagementWatcher(ctx context.Context, platformClient *platform.Client,
+	kubeClientSet *clientset.Clientset, hubClientSet *hubclientset.Clientset, traefikClientSet v1alpha1.TraefikV1alpha1Interface,
+	kubeInformer informers.SharedInformerFactory, hubInformer hubinformer.SharedInformerFactory,
+	portalWatcherCfg *api.WatcherPortalConfig, gatewayWatcherCfg *api.WatcherGatewayConfig, cfgWatcher *platform.ConfigWatcher) error {
+
+	portalWatcher := api.NewWatcherPortal(platformClient, kubeClientSet, kubeInformer, hubClientSet, hubInformer, portalWatcherCfg)
+	gatewayWatcher := api.NewWatcherGateway(platformClient, kubeClientSet, kubeInformer, hubClientSet, hubInformer, traefikClientSet, gatewayWatcherCfg)
+	apiWatcher := api.NewWatcherAPI(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
+	collectionWatcher := api.NewWatcherCollection(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
+	accessWatcher := api.NewWatcherAccess(platformClient, hubClientSet, hubInformer, portalWatcherCfg.PortalSyncInterval)
+
+	cfg, err := platformClient.GetConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("get config: %w", err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	var watcherStarted bool
+	stopWatchers := func() {
+		cancel()
+		watcherStarted = false
+	}
+	startWatchers := func() {
+		go portalWatcher.Run(ctx)
+		go gatewayWatcher.Run(ctx)
+		go apiWatcher.Run(ctx)
+		go collectionWatcher.Run(ctx)
+		go accessWatcher.Run(ctx)
+
+		watcherStarted = true
+	}
+
+	if slices.Contains(cfg.Features, apiManagementFeature) {
+		startWatchers()
+	}
+
+	cfgWatcher.AddListener(func(cfg platform.Config) {
+		if slices.Contains(cfg.Features, apiManagementFeature) {
+			if !watcherStarted {
+				startWatchers()
+			}
+		} else if watcherStarted {
+			stopWatchers()
+		}
+	})
+
+	return nil
 }
 
 func createTraefikClientSet(clientSet *clientset.Clientset, config *rest.Config) (v1alpha1.TraefikV1alpha1Interface, error) {
@@ -478,7 +524,7 @@ func hasMiddlewareCRD(clientSet discovery.DiscoveryInterface) (bool, error) {
 	return true, nil
 }
 
-func isAPIAvailable(clientSet discovery.DiscoveryInterface) (bool, error) {
+func hasAPIManagementCRDs(clientSet discovery.DiscoveryInterface) (bool, error) {
 	crdList, err := clientSet.ServerResourcesForGroupVersion(hubv1alpha1.SchemeGroupVersion.String())
 	if err != nil {
 		if kerror.IsNotFound(err) {

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -75,7 +75,8 @@ type ACP struct {
 
 // Config holds the configuration of the offer.
 type Config struct {
-	Metrics MetricsConfig `json:"metrics"`
+	Metrics  MetricsConfig `json:"metrics"`
+	Features []string      `json:"features"`
 }
 
 // MetricsConfig holds the metrics part of the offer config.


### PR DESCRIPTION
API management watcher will be started only if the agent config allows such feature. 