### PR TITLE
fix: obtain groups from the platform instead of ID token

### DIFF
--- a/pkg/api/devportal/api_test.go
+++ b/pkg/api/devportal/api_test.go
@@ -259,7 +259,6 @@ func TestPortalAPI_Router_listTokens(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -332,7 +331,6 @@ func TestPortalAPI_Router_createToken(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -403,7 +401,6 @@ func TestPortalAPI_Router_suspendToken(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -459,7 +456,6 @@ func TestPortalAPI_Router_deleteToken(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -470,7 +466,10 @@ func TestPortalAPI_Router_deleteToken(t *testing.T) {
 }
 
 func TestPortalAPI_Router_listAPIs(t *testing.T) {
-	a, err := NewPortalAPI(&testPortal, nil)
+	platformClient := newPlatformClientMock(t)
+	platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
+	a, err := NewPortalAPI(&testPortal, platformClient)
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(a)
@@ -479,7 +478,6 @@ func TestPortalAPI_Router_listAPIs(t *testing.T) {
 	require.NoError(t, err)
 
 	req.Header.Add("Hub-Email", testEmail)
-	req.Header.Add("Hub-Groups", "supplier")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -511,14 +509,19 @@ func TestPortalAPI_Router_listAPIs(t *testing.T) {
 }
 
 func TestPortalAPI_Router_listAPIs_noAPIsAndCollections(t *testing.T) {
+	platformClient := newPlatformClientMock(t)
+	platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
 	var p portal
-	a, err := NewPortalAPI(&p, nil)
+	a, err := NewPortalAPI(&p, platformClient)
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(a)
 
 	req, err := http.NewRequest(http.MethodGet, srv.URL+"/apis", http.NoBody)
 	require.NoError(t, err)
+
+	req.Header.Add("Hub-Email", testEmail)
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -590,7 +593,10 @@ func TestPortalAPI_Router_getCollectionAPISpec(t *testing.T) {
 				}
 			}))
 
-			a, err := NewPortalAPI(&testPortal, nil)
+			platformClient := newPlatformClientMock(t)
+			platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
+			a, err := NewPortalAPI(&testPortal, platformClient)
 			require.NoError(t, err)
 			a.httpClient = buildProxyClient(t, svcSrv.URL)
 
@@ -601,7 +607,6 @@ func TestPortalAPI_Router_getCollectionAPISpec(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -755,7 +760,10 @@ func TestPortalAPI_Router_getCollectionAPISpec_overrideServerAndAuth(t *testing.
 		test := test
 
 		t.Run(test.desc, func(t *testing.T) {
-			a, err := NewPortalAPI(&test.portal, nil)
+			platformClient := newPlatformClientMock(t)
+			platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
+			a, err := NewPortalAPI(&test.portal, platformClient)
 			require.NoError(t, err)
 			a.httpClient = http.DefaultClient
 
@@ -765,7 +773,6 @@ func TestPortalAPI_Router_getCollectionAPISpec_overrideServerAndAuth(t *testing.
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -839,7 +846,11 @@ func TestPortalAPI_Router_getAPISpec(t *testing.T) {
 					rw.WriteHeader(http.StatusInternalServerError)
 				}
 			}))
-			a, err := NewPortalAPI(&testPortal, nil)
+
+			platformClient := newPlatformClientMock(t)
+			platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
+			a, err := NewPortalAPI(&testPortal, platformClient)
 			require.NoError(t, err)
 			a.httpClient = buildProxyClient(t, svcSrv.URL)
 
@@ -849,7 +860,6 @@ func TestPortalAPI_Router_getAPISpec(t *testing.T) {
 			require.NoError(t, err)
 
 			req.Header.Add("Hub-Email", testEmail)
-			req.Header.Add("Hub-Groups", "supplier")
 
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(t, err)
@@ -899,7 +909,10 @@ func TestPortalAPI_Router_getAPISpec_overrideServerAndAuth(t *testing.T) {
 		},
 	}
 
-	a, err := NewPortalAPI(&p, nil)
+	platformClient := newPlatformClientMock(t)
+	platformClient.OnGetUserGroups(testEmail).TypedReturns([]string{"supplier"}, nil)
+
+	a, err := NewPortalAPI(&p, platformClient)
 	require.NoError(t, err)
 	a.httpClient = http.DefaultClient
 
@@ -910,7 +923,6 @@ func TestPortalAPI_Router_getAPISpec_overrideServerAndAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	req.Header.Add("Hub-Email", testEmail)
-	req.Header.Add("Hub-Groups", "supplier")
 
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)

--- a/pkg/api/devportal/handler.go
+++ b/pkg/api/devportal/handler.go
@@ -33,6 +33,7 @@ type PlatformClient interface {
 	CreateUserToken(ctx context.Context, userEmail, tokenName string) (string, error)
 	SuspendUserToken(ctx context.Context, userEmail, tokenName string, suspend bool) error
 	DeleteUserToken(ctx context.Context, userEmail, tokenName string) error
+	GetUserGroups(ctx context.Context, userEmail string) ([]string, error)
 }
 
 // Handler exposes both an API and a UI for a set of APIPortals.

--- a/pkg/api/devportal/mock_gen_test.go
+++ b/pkg/api/devportal/mock_gen_test.go
@@ -225,6 +225,10 @@ func (_c *platformClientCreateUserTokenCall) OnDeleteUserToken(userEmail string,
 	return _c.Parent.OnDeleteUserToken(userEmail, tokenName)
 }
 
+func (_c *platformClientCreateUserTokenCall) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroups(userEmail)
+}
+
 func (_c *platformClientCreateUserTokenCall) OnListUserTokens(userEmail string) *platformClientListUserTokensCall {
 	return _c.Parent.OnListUserTokens(userEmail)
 }
@@ -239,6 +243,10 @@ func (_c *platformClientCreateUserTokenCall) OnCreateUserTokenRaw(userEmail inte
 
 func (_c *platformClientCreateUserTokenCall) OnDeleteUserTokenRaw(userEmail interface{}, tokenName interface{}) *platformClientDeleteUserTokenCall {
 	return _c.Parent.OnDeleteUserTokenRaw(userEmail, tokenName)
+}
+
+func (_c *platformClientCreateUserTokenCall) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroupsRaw(userEmail)
 }
 
 func (_c *platformClientCreateUserTokenCall) OnListUserTokensRaw(userEmail interface{}) *platformClientListUserTokensCall {
@@ -341,6 +349,10 @@ func (_c *platformClientDeleteUserTokenCall) OnDeleteUserToken(userEmail string,
 	return _c.Parent.OnDeleteUserToken(userEmail, tokenName)
 }
 
+func (_c *platformClientDeleteUserTokenCall) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroups(userEmail)
+}
+
 func (_c *platformClientDeleteUserTokenCall) OnListUserTokens(userEmail string) *platformClientListUserTokensCall {
 	return _c.Parent.OnListUserTokens(userEmail)
 }
@@ -357,11 +369,139 @@ func (_c *platformClientDeleteUserTokenCall) OnDeleteUserTokenRaw(userEmail inte
 	return _c.Parent.OnDeleteUserTokenRaw(userEmail, tokenName)
 }
 
+func (_c *platformClientDeleteUserTokenCall) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroupsRaw(userEmail)
+}
+
 func (_c *platformClientDeleteUserTokenCall) OnListUserTokensRaw(userEmail interface{}) *platformClientListUserTokensCall {
 	return _c.Parent.OnListUserTokensRaw(userEmail)
 }
 
 func (_c *platformClientDeleteUserTokenCall) OnSuspendUserTokenRaw(userEmail interface{}, tokenName interface{}, suspend interface{}) *platformClientSuspendUserTokenCall {
+	return _c.Parent.OnSuspendUserTokenRaw(userEmail, tokenName, suspend)
+}
+
+func (_m *platformClientMock) GetUserGroups(_ context.Context, userEmail string) ([]string, error) {
+	_ret := _m.Called(userEmail)
+
+	if _rf, ok := _ret.Get(0).(func(string) ([]string, error)); ok {
+		return _rf(userEmail)
+	}
+
+	_ra0, _ := _ret.Get(0).([]string)
+	_rb1 := _ret.Error(1)
+
+	return _ra0, _rb1
+}
+
+func (_m *platformClientMock) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return &platformClientGetUserGroupsCall{Call: _m.Mock.On("GetUserGroups", userEmail), Parent: _m}
+}
+
+func (_m *platformClientMock) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return &platformClientGetUserGroupsCall{Call: _m.Mock.On("GetUserGroups", userEmail), Parent: _m}
+}
+
+type platformClientGetUserGroupsCall struct {
+	*mock.Call
+	Parent *platformClientMock
+}
+
+func (_c *platformClientGetUserGroupsCall) Panic(msg string) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Panic(msg)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) Once() *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Once()
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) Twice() *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Twice()
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) Times(i int) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Times(i)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) WaitUntil(w <-chan time.Time) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.WaitUntil(w)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) After(d time.Duration) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.After(d)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) Run(fn func(args mock.Arguments)) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Run(fn)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) Maybe() *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Maybe()
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) TypedReturns(a []string, b error) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Return(a, b)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) ReturnsFn(fn func(string) ([]string, error)) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Return(fn)
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) TypedRun(fn func(string)) *platformClientGetUserGroupsCall {
+	_c.Call = _c.Call.Run(func(args mock.Arguments) {
+		_userEmail := args.String(0)
+		fn(_userEmail)
+	})
+	return _c
+}
+
+func (_c *platformClientGetUserGroupsCall) OnCreateUserToken(userEmail string, tokenName string) *platformClientCreateUserTokenCall {
+	return _c.Parent.OnCreateUserToken(userEmail, tokenName)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnDeleteUserToken(userEmail string, tokenName string) *platformClientDeleteUserTokenCall {
+	return _c.Parent.OnDeleteUserToken(userEmail, tokenName)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroups(userEmail)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnListUserTokens(userEmail string) *platformClientListUserTokensCall {
+	return _c.Parent.OnListUserTokens(userEmail)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnSuspendUserToken(userEmail string, tokenName string, suspend bool) *platformClientSuspendUserTokenCall {
+	return _c.Parent.OnSuspendUserToken(userEmail, tokenName, suspend)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnCreateUserTokenRaw(userEmail interface{}, tokenName interface{}) *platformClientCreateUserTokenCall {
+	return _c.Parent.OnCreateUserTokenRaw(userEmail, tokenName)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnDeleteUserTokenRaw(userEmail interface{}, tokenName interface{}) *platformClientDeleteUserTokenCall {
+	return _c.Parent.OnDeleteUserTokenRaw(userEmail, tokenName)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroupsRaw(userEmail)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnListUserTokensRaw(userEmail interface{}) *platformClientListUserTokensCall {
+	return _c.Parent.OnListUserTokensRaw(userEmail)
+}
+
+func (_c *platformClientGetUserGroupsCall) OnSuspendUserTokenRaw(userEmail interface{}, tokenName interface{}, suspend interface{}) *platformClientSuspendUserTokenCall {
 	return _c.Parent.OnSuspendUserTokenRaw(userEmail, tokenName, suspend)
 }
 
@@ -457,6 +597,10 @@ func (_c *platformClientListUserTokensCall) OnDeleteUserToken(userEmail string, 
 	return _c.Parent.OnDeleteUserToken(userEmail, tokenName)
 }
 
+func (_c *platformClientListUserTokensCall) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroups(userEmail)
+}
+
 func (_c *platformClientListUserTokensCall) OnListUserTokens(userEmail string) *platformClientListUserTokensCall {
 	return _c.Parent.OnListUserTokens(userEmail)
 }
@@ -471,6 +615,10 @@ func (_c *platformClientListUserTokensCall) OnCreateUserTokenRaw(userEmail inter
 
 func (_c *platformClientListUserTokensCall) OnDeleteUserTokenRaw(userEmail interface{}, tokenName interface{}) *platformClientDeleteUserTokenCall {
 	return _c.Parent.OnDeleteUserTokenRaw(userEmail, tokenName)
+}
+
+func (_c *platformClientListUserTokensCall) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroupsRaw(userEmail)
 }
 
 func (_c *platformClientListUserTokensCall) OnListUserTokensRaw(userEmail interface{}) *platformClientListUserTokensCall {
@@ -574,6 +722,10 @@ func (_c *platformClientSuspendUserTokenCall) OnDeleteUserToken(userEmail string
 	return _c.Parent.OnDeleteUserToken(userEmail, tokenName)
 }
 
+func (_c *platformClientSuspendUserTokenCall) OnGetUserGroups(userEmail string) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroups(userEmail)
+}
+
 func (_c *platformClientSuspendUserTokenCall) OnListUserTokens(userEmail string) *platformClientListUserTokensCall {
 	return _c.Parent.OnListUserTokens(userEmail)
 }
@@ -588,6 +740,10 @@ func (_c *platformClientSuspendUserTokenCall) OnCreateUserTokenRaw(userEmail int
 
 func (_c *platformClientSuspendUserTokenCall) OnDeleteUserTokenRaw(userEmail interface{}, tokenName interface{}) *platformClientDeleteUserTokenCall {
 	return _c.Parent.OnDeleteUserTokenRaw(userEmail, tokenName)
+}
+
+func (_c *platformClientSuspendUserTokenCall) OnGetUserGroupsRaw(userEmail interface{}) *platformClientGetUserGroupsCall {
+	return _c.Parent.OnGetUserGroupsRaw(userEmail)
 }
 
 func (_c *platformClientSuspendUserTokenCall) OnListUserTokensRaw(userEmail interface{}) *platformClientListUserTokensCall {

--- a/pkg/api/watcher_portal.go
+++ b/pkg/api/watcher_portal.go
@@ -355,15 +355,14 @@ func (w *WatcherPortal) upsertPortalACP(ctx context.Context, portal *hubv1alpha1
 				ClientID:    hubACPConfig.ClientID,
 				Scopes:      []string{"openid", "offline_access"},
 				Session: &hubv1alpha1.Session{
-					Refresh: pointer.Bool(true),
+					Refresh: pointer.Bool(false),
 				},
 				Secret: &corev1.SecretReference{
 					Name:      acpName,
 					Namespace: w.config.AgentNamespace,
 				},
 				ForwardHeaders: map[string]string{
-					"Hub-Groups": "groups",
-					"Hub-Email":  "sub",
+					"Hub-Email": "sub",
 				},
 			},
 		},

--- a/pkg/platform/client_user_group.go
+++ b/pkg/platform/client_user_group.go
@@ -1,0 +1,52 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+
+	"github.com/traefik/hub-agent-kubernetes/pkg/version"
+)
+
+// GetUserGroups get the groups of a user given its email address.
+func (c *Client) GetUserGroups(ctx context.Context, userEmail string) ([]string, error) {
+	baseURL, err := c.baseURL.Parse(path.Join(c.baseURL.Path, "users", userEmail, "groups"))
+	if err != nil {
+		return nil, fmt.Errorf("parse endpoint: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL.String(), http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	version.SetUserAgent(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		all, _ := io.ReadAll(resp.Body)
+
+		apiErr := APIError{StatusCode: resp.StatusCode}
+		if err = json.Unmarshal(all, &apiErr); err != nil {
+			apiErr.Message = string(all)
+		}
+
+		return nil, apiErr
+	}
+
+	var groups []string
+	if err = json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+		return nil, fmt.Errorf("decode groups: %w", err)
+	}
+
+	return groups, nil
+}

--- a/pkg/platform/client_user_group_test.go
+++ b/pkg/platform/client_user_group_test.go
@@ -1,0 +1,47 @@
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_GetUserGroups(t *testing.T) {
+	wantGroups := []string{"group-1", "group-2"}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/users/test@example.com/groups", func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			http.Error(rw, fmt.Sprintf("unexpected method: %s", req.Method), http.StatusMethodNotAllowed)
+			return
+		}
+
+		if req.Header.Get("Authorization") != "Bearer "+testToken {
+			http.Error(rw, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		rw.WriteHeader(http.StatusOK)
+		err := json.NewEncoder(rw).Encode(wantGroups)
+		require.NoError(t, err)
+	})
+
+	srv := httptest.NewServer(mux)
+
+	t.Cleanup(srv.Close)
+
+	c, err := NewClient(srv.URL, testToken)
+	require.NoError(t, err)
+	c.httpClient = srv.Client()
+
+	gotGroups, err := c.GetUserGroups(context.Background(), "test@example.com")
+	require.NoError(t, err)
+
+	assert.Equal(t, wantGroups, gotGroups)
+}


### PR DESCRIPTION
This removes changes the way we obtain user groups. We used to get them from the Hub-Groups header which was forwarded by the OIDC middleware (value coming from the ID token). We not ask directly the platform. 

Refresh tokens used to trigger the verification of user groups. If they changed the ID token was changed accordingly. This forced us to have frequent refresh. This frequent refresh increased drastically the chance of doing concurrent refresh of the token, which is not allowed by OIDC. 

This call to the platform is not on the critical path but a follow up PR could be made to add some client-side caching.